### PR TITLE
Rename cargobomb to crater in code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,5 +1,5 @@
 [root]
-name = "cargobomb"
+name = "crater"
 version = "0.1.0"
 dependencies = [
  "arc-cell 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargobomb"
+name = "crater"
 version = "0.1.0"
 authors = ["Brian Anderson <banderson@mozilla.com>"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,11 +16,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --install-suggests libgtk-
 
 WORKDIR /source
 
-# Create a cargobomb user that run.sh will map to the value of the host user via
+# Create a crater user that run.sh will map to the value of the host user via
 # the USER_ID environment variable, to make the files the container writes not
 # be owned by root, but by the running host user
 # re https://github.com/docker/docker/issues/7198#issuecomment-158566258
-RUN adduser --no-create-home --disabled-login --gecos "" cargobomb --uid 1000
+RUN adduser --no-create-home --disabled-login --gecos "" crater --uid 1000
 
 # The run.sh script configures the user id, controlled by -e USER_ID, and then
 # runs some command, controlled by -e CMD

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-usermod -u "$USER_ID" cargobomb
+usermod -u "$USER_ID" crater
 if [ -e /var/run/docker.sock ]; then
     groupmod -g "$DOCKER_GROUP_ID" docker
-    usermod -G docker cargobomb
+    usermod -G docker crater
 fi
-exec su cargobomb -c "/run2.sh $CMD"
+exec su crater -c "/run2.sh $CMD"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 /*!
 
-Cargobomb works by serially processing a queue of commands, each of
+Crater works by serially processing a queue of commands, each of
 which transforms the application state in some discrete way, and
 designed to be resilient to I/O errors. The application state is
 backed by a directory in the filesystem, and optionally synchronized
@@ -17,15 +17,15 @@ rewrite.
 
 */
 
-use cargobomb::docker;
-use cargobomb::errors::*;
-use cargobomb::ex;
-use cargobomb::ex::{ExCrate, ExCrateSelect, ExMode};
-use cargobomb::ex_run;
-use cargobomb::lists;
-use cargobomb::report;
-use cargobomb::server;
-use cargobomb::toolchain::Toolchain;
+use crater::docker;
+use crater::errors::*;
+use crater::ex;
+use crater::ex::{ExCrate, ExCrateSelect, ExMode};
+use crater::ex_run;
+use crater::lists;
+use crater::report;
+use crater::server;
+use crater::toolchain::Toolchain;
 use std::env;
 use std::path::PathBuf;
 use std::str::FromStr;

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -5,9 +5,9 @@ use std::fmt::{self, Display, Formatter};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-static IMAGE_NAME: &'static str = "cargobomb";
+static IMAGE_NAME: &'static str = "crater";
 
-/// Builds the docker container image, 'cargobomb', what will be used
+/// Builds the docker container image, 'crater', what will be used
 /// to isolate builds from each other. This expects the Dockerfile
 /// to exist in the `docker` directory, at runtime.
 pub fn build_container() -> Result<()> {

--- a/src/ex_run.rs
+++ b/src/ex_run.rs
@@ -76,7 +76,7 @@ fn run_exts(ex: &Experiment, tcs: &[Toolchain]) -> Result<()> {
                     info!("skipping crate {}. existing result: {}", c, r);
                     info!(
                         "delete result file to rerun test: \
-                           \"cargobomb delete-result {} --toolchain {} {}\"",
+                           \"crater delete-result {} --toolchain {} {}\"",
                         ex.name,
                         tc.to_string(),
                         c

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -54,7 +54,7 @@ impl List for RecentList {
 
     fn read() -> Result<Vec<Crate>> {
         let lines = file::read_lines(&Self::path()).chain_err(
-            || "unable to read recent list. run `cargobomb create-lists`?",
+            || "unable to read recent list. run `crater create-lists`?",
         )?;
         split_crate_lines(&lines)
     }
@@ -134,7 +134,7 @@ impl List for PopList {
 
     fn read() -> Result<Vec<Crate>> {
         let lines = file::read_lines(&Self::path()).chain_err(
-            || "unable to read pop list. run `cargobomb create-lists`?",
+            || "unable to read pop list. run `crater create-lists`?",
         )?;
         split_crate_lines(&lines)
     }
@@ -217,7 +217,7 @@ impl List for HotList {
 
     fn read() -> Result<Vec<Crate>> {
         let lines = file::read_lines(&Self::path()).chain_err(
-            || "unable to read hot list. run `cargobomb create-lists`?",
+            || "unable to read hot list. run `crater create-lists`?",
         )?;
         split_crate_lines(&lines)
     }
@@ -244,7 +244,7 @@ impl List for GitHubCandidateList {
         Ok(
             file::read_lines(&Self::path())
                 .chain_err(
-                    || "unable to read gh-candidates list. run `cargobomb create-lists`?",
+                    || "unable to read gh-candidates list. run `crater create-lists`?",
                 )?
                 .into_iter()
                 .map(|line| Crate::Repo { url: line })
@@ -308,7 +308,7 @@ impl List for GitHubAppList {
         Ok(
             file::read_lines(&GitHubAppList::path())
                 .chain_err(
-                    || "unable to read gh-app list. run `cargobomb create-lists`?",
+                    || "unable to read gh-app list. run `crater create-lists`?",
                 )?
                 .into_iter()
                 .map(|line| Crate::Repo { url: line })
@@ -407,7 +407,7 @@ pub fn read_all_lists() -> Result<Vec<Crate>> {
     }
 
     if all.is_empty() {
-        bail!("no crates loaded. run `cargobomb prepare-lists`?");
+        bail!("no crates loaded. run `crater prepare-lists`?");
     }
 
     let mut all: Vec<_> = all.drain().collect();

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -307,9 +307,7 @@ impl List for GitHubAppList {
     fn read() -> Result<Vec<Crate>> {
         Ok(
             file::read_lines(&GitHubAppList::path())
-                .chain_err(
-                    || "unable to read gh-app list. run `crater create-lists`?",
-                )?
+                .chain_err(|| "unable to read gh-app list. run `crater create-lists`?")?
                 .into_iter()
                 .map(|line| Crate::Repo { url: line })
                 .collect(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,9 @@ extern crate crater;
 
 mod cli;
 
+use clap::{App, AppSettings};
 use crater::{log, util};
 use crater::errors::*;
-use clap::{App, AppSettings};
 use std::panic;
 use std::process;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,12 +10,12 @@ extern crate structopt;
 #[macro_use]
 extern crate structopt_derive;
 
-extern crate cargobomb;
+extern crate crater;
 
 mod cli;
 
-use cargobomb::{log, util};
-use cargobomb::errors::*;
+use crater::{log, util};
+use crater::errors::*;
 use clap::{App, AppSettings};
 use std::panic;
 use std::process;
@@ -57,7 +57,7 @@ fn main_() -> Result<()> {
 }
 
 fn cli() -> App<'static, 'static> {
-    App::new("cargobomb")
+    App::new("crater")
         .version(env!("CARGO_PKG_VERSION"))
         .about("Kaboom!")
         .setting(AppSettings::VersionlessSubcommands)

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -122,7 +122,7 @@ fn install_rustup() -> Result<()> {
         || "unable to download rustup",
     )?;
 
-    let tempdir = TempDir::new("cargobomb")?;
+    let tempdir = TempDir::new("crater")?;
     let installer = &tempdir.path().join(format!("rustup-init{}", EXE_SUFFIX));
     {
         let mut file = File::create(installer)?;

--- a/todo.md
+++ b/todo.md
@@ -130,7 +130,7 @@ $ du work/shared/crates/ -hs
 # Building docker container
 
 ```
-docker build -t cargobomb docker
+docker build -t crater docker
 ```
 
 # Data model


### PR DESCRIPTION
Renames usages of cargobomb in the code to crater as part of  #134
This might break the world...but hopefully it is ok :). There may be context that I'm not aware of though.

Some of these changes may not be desired - can back them out if they've gone too far.
Note:
 - Changes the executable name - users would need to be made aware that it changed
 - Changes the docker image name - docker is smart enough to use its caches so is quick to rebuild
 - Changes the docker user name - as long is it's consistent I can't see why it would break anything

The local running steps all still seem to work with these changes.
