### PR TITLE
Generate Cargo.lock on the last toolchain.

### DIFF
--- a/src/ex.rs
+++ b/src/ex.rs
@@ -175,7 +175,7 @@ impl Experiment {
         capture_shas(self)?;
         download_crates(self)?;
         frob_tomls(self)?;
-        capture_lockfiles(self, &Toolchain::Dist("stable".into()), false)?;
+        capture_lockfiles(self, self.toolchains.last().unwrap(), false)?;
         Ok(())
     }
 
@@ -183,7 +183,7 @@ impl Experiment {
         // Local experiment prep
         delete_all_target_dirs(&self.name)?;
         ex_run::delete_all_results(&self.name)?;
-        fetch_deps(self, &Toolchain::Dist("stable".into()))?;
+        fetch_deps(self, self.toolchains.last().unwrap())?;
         prepare_all_toolchains(self)?;
 
         Ok(())


### PR DESCRIPTION
Previously, we generated these on stable, and that meant that when Cargo
updated the lockfile format on nightly, our runs would fail. This fixes
that problem, since we now have the most recent toolchain generate the
lockfiles.

I suspect this will fail CI because @brson's hello-rs lockfile is outdated, and we don't (re?)generate lockfiles for git repos. Let me know if there's something else I need to update for that.

Fixes https://github.com/rust-lang-nursery/crater/issues/145.