### PR TITLE
Add links to each crate on crates.io or github in report html.

### DIFF
--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -23,6 +23,7 @@ pub struct TestResults {
 #[derive(Serialize, Deserialize)]
 struct CrateResult {
     name: String,
+    url: String,
     res: Comparison,
     runs: [Option<BuildTestResult>; 2],
 }
@@ -72,6 +73,7 @@ pub fn generate_report(ex: &ex::Experiment) -> Result<TestResults> {
 
             CrateResult {
                 name: crate_to_name(&krate),
+                url: crate_to_url(&krate),
                 res: comp,
                 runs: [crate1, crate2],
             }
@@ -152,6 +154,20 @@ fn crate_to_name(c: &ex::ExCrate) -> String {
             ref name,
             ref sha,
         } => format!("{}.{}.{}", org, name, sha),
+    }
+}
+
+fn crate_to_url(c: &ex::ExCrate) -> String {
+    match *c {
+        ex::ExCrate::Version {
+            ref name,
+            ref version,
+        } => format!("https://crates.io/crates/{}/{}", name, version),
+        ex::ExCrate::Repo {
+            ref org,
+            ref name,
+            ref sha,
+        } => format!("https://github.com/{}/{}/tree/{}", org, name, sha),
     }
 }
 

--- a/static/report.js
+++ b/static/report.js
@@ -147,7 +147,7 @@ function insertResults(results) {
 
 	let row = `
 	<div class="${res}">
-	    <span><a href="${url}" target="_blank">${name}</a></span>
+	    <span><a href="${url}" target="_blank" rel="noopener">${name}</a></span>
 	    ${html1}
 	    ${html2}
         </div>

--- a/static/report.js
+++ b/static/report.js
@@ -128,10 +128,11 @@ function insertResults(results) {
     let resultsTableEl = document.getElementById("results");
 
     for (crate of results.crates) {
-	let name = crate.name;
-	let res = jsonCrateResToCss(crate.res);
-	let run1 = parseRunResult(crate.runs[0]);
-	let run2 = parseRunResult(crate.runs[1]);
+        let name = crate.name;
+        let url = crate.url;
+        let res = jsonCrateResToCss(crate.res);
+        let run1 = parseRunResult(crate.runs[0]);
+        let run2 = parseRunResult(crate.runs[1]);
 
         function runToHtml(run) {
             if (run.log) {
@@ -146,7 +147,7 @@ function insertResults(results) {
 
 	let row = `
 	<div class="${res}">
-	    <span>${name}</span>
+	    <span><a href="${url}" target="_blank">${name}</a></span>
 	    ${html1}
 	    ${html2}
         </div>


### PR DESCRIPTION
Addresses #118.
This turns the name of each crate in the report into a link to either the crates.io page for that version, or the github source at that sha.
