### PR TITLE
Add backtraces to the crater execution environment

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -100,6 +100,7 @@ pub fn rust_container(config: RustEnv) -> ContainerConfig {
         ("USER_ID", format!("{}", user_id())),
         ("CMD", config.args.join(" ")),
         ("CARGO_INCREMENTAL", "0".to_string()),
+        ("RUST_BACKTRACE", "full".to_string()),
     ];
 
     ContainerConfig {


### PR DESCRIPTION
This PR adds the `RUST_BACKTRACE=full` environment variable to the Docker container crater uses, to get full backtraces when the compiler panics.

This can be useful if the ICE is something generic (such as "Option::unwrap panicked") and can't be reproduced locally, to catch sporadic failures in the compiler itself.