### PR TITLE
Group skipped crates in their own section

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -250,7 +250,7 @@ impl Crater {
                 report::gen(&ex.0, &report::S3Writer::create(s3_prefix)?, &config)?;
             }
             Crater::Serve => {
-                server::start(server::Data);
+                server::start(server::Data { config });
             }
         }
 

--- a/src/ex_run.rs
+++ b/src/ex_run.rs
@@ -54,6 +54,7 @@ fn run_exts(ex: &Experiment, tcs: &[Toolchain], config: &Config) -> Result<()> {
     let mut sum_errors = 0;
     let mut sum_build_fail = 0;
     let mut sum_test_fail = 0;
+    let mut sum_test_skipped = 0;
     let mut sum_test_pass = 0;
 
     let start_time = Instant::now();
@@ -131,6 +132,7 @@ fn run_exts(ex: &Experiment, tcs: &[Toolchain], config: &Config) -> Result<()> {
                 }
                 Ok(TestResult::BuildFail) => sum_build_fail += 1,
                 Ok(TestResult::TestFail) => sum_test_fail += 1,
+                Ok(TestResult::TestSkipped) => sum_test_skipped += 1,
                 Ok(TestResult::TestPass) => sum_test_pass += 1,
             }
 
@@ -161,8 +163,8 @@ fn run_exts(ex: &Experiment, tcs: &[Toolchain], config: &Config) -> Result<()> {
                 completed_crates, elapsed, seconds_per_test, remaining_tests, remaining_time_str
             );
             info!(
-                "results: {} build-fail / {} test-fail / {} test-pass / {} errors",
-                sum_build_fail, sum_test_fail, sum_test_pass, sum_errors
+                "results: {} build-fail / {} test-fail / {} test-skipped / {} test-pass / {} errors",
+                sum_build_fail, sum_test_fail, sum_test_skipped, sum_test_pass, sum_errors
             );
         }
     }
@@ -236,7 +238,7 @@ fn test_build_only(
 ) -> Result<TestResult> {
     let r = build(ex, source_path, toolchain, quiet);
     if r.is_ok() {
-        Ok(TestResult::TestPass)
+        Ok(TestResult::TestSkipped)
     } else {
         Ok(TestResult::BuildFail)
     }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -33,6 +33,7 @@ struct CrateResult {
 enum Comparison {
     Regressed,
     Fixed,
+    Skipped,
     Unknown,
     SameBuildFail,
     SameTestFail,
@@ -45,7 +46,7 @@ struct BuildTestResult {
     log: String,
 }
 
-pub fn generate_report(ex: &ex::Experiment) -> Result<TestResults> {
+pub fn generate_report(config: &Config, ex: &ex::Experiment) -> Result<TestResults> {
     let db = FileDB::for_experiment(ex);
     assert_eq!(ex.toolchains.len(), 2);
 
@@ -69,7 +70,7 @@ pub fn generate_report(ex: &ex::Experiment) -> Result<TestResults> {
             let mut crate_results = crate_results.map(|r| r.ok()).collect::<Vec<_>>();
             let crate2 = crate_results.pop().expect("");
             let crate1 = crate_results.pop().expect("");
-            let comp = compare(&crate1, &crate2);
+            let comp = compare(config, &krate, &crate1, &crate2);
 
             CrateResult {
                 name: crate_to_name(&krate),
@@ -117,7 +118,7 @@ fn write_logs<W: ReportWriter>(ex: &ex::Experiment, dest: &W, config: &Config) -
 pub fn gen<W: ReportWriter + Display>(ex_name: &str, dest: &W, config: &Config) -> Result<()> {
     let ex = ex::Experiment::load(ex_name)?;
 
-    let res = generate_report(&ex)?;
+    let res = generate_report(&config, &ex)?;
     let shas = ex.load_shas()?;
 
     info!("writing results to {}", dest);
@@ -174,7 +175,12 @@ fn crate_to_url(c: &ex::ExCrate) -> String {
     }
 }
 
-fn compare(r1: &Option<BuildTestResult>, r2: &Option<BuildTestResult>) -> Comparison {
+fn compare(
+    config: &Config,
+    krate: &ex::ExCrate,
+    r1: &Option<BuildTestResult>,
+    r2: &Option<BuildTestResult>,
+) -> Comparison {
     use results::TestResult::*;
     match (r1, r2) {
         (
@@ -191,6 +197,7 @@ fn compare(r1: &Option<BuildTestResult>, r2: &Option<BuildTestResult>) -> Compar
                 Comparison::Regressed
             }
         },
+        _ if config.should_skip(krate) => Comparison::Skipped,
         _ => Comparison::Unknown,
     }
 }

--- a/src/results.rs
+++ b/src/results.rs
@@ -155,6 +155,7 @@ impl<'a> ResultWriter<'a> {
 pub enum TestResult {
     BuildFail,
     TestFail,
+    TestSkipped,
     TestPass,
 }
 impl Display for TestResult {
@@ -170,6 +171,7 @@ impl FromStr for TestResult {
         match s {
             "build-fail" => Ok(TestResult::BuildFail),
             "test-fail" => Ok(TestResult::TestFail),
+            "test-skipped" => Ok(TestResult::TestSkipped),
             "test-pass" => Ok(TestResult::TestPass),
             _ => Err(format!("bogus test result: {}", s).into()),
         }
@@ -181,6 +183,7 @@ impl TestResult {
         match *self {
             TestResult::BuildFail => "build-fail",
             TestResult::TestFail => "test-fail",
+            TestResult::TestSkipped => "test-skipped",
             TestResult::TestPass => "test-pass",
         }.to_string()
     }

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -47,10 +47,10 @@ pub mod ex_report {
     use server::{Data, Params};
 
     #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-    pub fn handler(_data: &Data, params: Params) -> TestResults {
+    pub fn handler(data: &Data, params: Params) -> TestResults {
         let ex_name = params.find("experiment").unwrap();
         let ex = ex::Experiment::load(ex_name).unwrap();
-        generate_report(&ex).unwrap()
+        generate_report(&data.config, &ex).unwrap()
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 use arc_cell::ArcCell;
+use config::Config;
 use futures::{self, Future, Stream};
 use futures_cpupool::CpuPool;
 use handlebars::Handlebars;
@@ -17,7 +18,9 @@ use std::sync::Arc;
 
 mod api;
 
-pub struct Data;
+pub struct Data {
+    pub config: Config,
+}
 
 type Handler = Box<
     Fn(&Server, Request, Params) -> Box<Future<Item = Response, Error = hyper::Error>>

--- a/static/report.css
+++ b/static/report.css
@@ -41,6 +41,10 @@ th {
     background-color: #788843;
 }
 
+.same-test-skipped {
+    background: repeating-linear-gradient(-45deg, #72A156, #72A156 15px, #80B65F 15px, #80B65F 30px);
+}
+
 .same-test-pass {
     background-color: #72A156;
 }

--- a/static/report.css
+++ b/static/report.css
@@ -49,6 +49,10 @@ th {
     background-color: #494B4A;
 }
 
+.skipped {
+    background: repeating-linear-gradient(-45deg, #494b4a, #494b4a 15px, #555 15px, #555 30px);
+}
+
 #controls {
     line-height: 3.5em;
     margin-bottom: 2rem;

--- a/static/report.js
+++ b/static/report.js
@@ -55,6 +55,7 @@ function begin(config, results) {
     let unknownEl = document.querySelector("#c-unknown .count");
     let sameBuildFailEl = document.querySelector("#c-same-build-fail .count");
     let sameTestFailEl = document.querySelector("#c-same-test-fail .count");
+    let sameTestSkippedEl = document.querySelector("#c-same-test-skipped .count");
     let sameTestPassEl = document.querySelector("#c-same-test-pass .count");
     let skippedEl = document.querySelector("#c-skipped .count");
 
@@ -63,6 +64,7 @@ function begin(config, results) {
     unknownEl.innerHTML = summary.unknown;
     sameBuildFailEl.innerHTML = summary.sameBuildFail;
     sameTestFailEl.innerHTML = summary.sameTestFail;
+    sameTestSkippedEl.innerHTML = summary.sameTestSkipped;
     sameTestPassEl.innerHTML = summary.sameTestPass;
     skippedEl.innerHTML = summary.skipped;
 
@@ -96,6 +98,7 @@ function calcSummary(results) {
     let unknown = 0;
     let sameBuildFail = 0;
     let sameTestFail = 0;
+    let sameTestSkipped = 0;
     let sameTestPass = 0;
     let skipped = 0;
 
@@ -110,7 +113,9 @@ function calcSummary(results) {
 	    sameBuildFail += 1;
 	} else if (crate.res == "SameTestFail") {
 	    sameTestFail += 1;
-	} else if (crate.res == "SameTestPass") {
+    } else if (crate.res == "SameTestSkipped") {
+        sameTestSkipped += 1;
+    } else if (crate.res == "SameTestPass") {
 	    sameTestPass += 1;
     } else if (crate.res == "Skipped") {
         skipped += 1;
@@ -125,6 +130,7 @@ function calcSummary(results) {
 	unknown: unknown,
 	sameBuildFail: sameBuildFail,
 	sameTestFail: sameTestFail,
+    sameTestSkipped: sameTestSkipped,
 	sameTestPass: sameTestPass,
     skipped: skipped,
     };
@@ -178,6 +184,8 @@ function jsonCrateResToCss(res) {
         return "same-build-fail";
     } else if (res == "SameTestFail") {
         return "same-test-fail";
+    } else if (res == "SameTestSkipped") {
+        return "same-test-skipped";
     } else if (res == "SameTestPass") {
         return "same-test-pass";
     } else if (res == "Skipped") {
@@ -201,7 +209,9 @@ function parseRunResult(crate_res, res) {
         if (res.res == "BuildFail") {
             result = "build-fail";
         } else if (res.res == "TestFail") {
-            result =  "test-fail";
+            result = "test-fail";
+        } else if (res.res == "TestSkipped") {
+            result = "test-skipped";
         } else if (res.res == "TestPass") {
             result = "test-pass";
         } else {

--- a/static/report.js
+++ b/static/report.js
@@ -56,6 +56,7 @@ function begin(config, results) {
     let sameBuildFailEl = document.querySelector("#c-same-build-fail .count");
     let sameTestFailEl = document.querySelector("#c-same-test-fail .count");
     let sameTestPassEl = document.querySelector("#c-same-test-pass .count");
+    let skippedEl = document.querySelector("#c-skipped .count");
 
     regressedEl.innerHTML = summary.regressed;
     fixedEl.innerHTML = summary.fixed;
@@ -63,6 +64,7 @@ function begin(config, results) {
     sameBuildFailEl.innerHTML = summary.sameBuildFail;
     sameTestFailEl.innerHTML = summary.sameTestFail;
     sameTestPassEl.innerHTML = summary.sameTestPass;
+    skippedEl.innerHTML = summary.skipped;
 
     // Creating the document will take a second. Lay out the summary first.
     let results_ = results;
@@ -95,6 +97,7 @@ function calcSummary(results) {
     let sameBuildFail = 0;
     let sameTestFail = 0;
     let sameTestPass = 0;
+    let skipped = 0;
 
     for (crate of results.crates) {
 	if (crate.res == "Regressed") {
@@ -109,7 +112,9 @@ function calcSummary(results) {
 	    sameTestFail += 1;
 	} else if (crate.res == "SameTestPass") {
 	    sameTestPass += 1;
-	} else {
+    } else if (crate.res == "Skipped") {
+        skipped += 1;
+    } else {
 	    throw "unknown test status";
 	}
     }
@@ -120,7 +125,8 @@ function calcSummary(results) {
 	unknown: unknown,
 	sameBuildFail: sameBuildFail,
 	sameTestFail: sameTestFail,
-	sameTestPass: sameTestPass
+	sameTestPass: sameTestPass,
+    skipped: skipped,
     };
 }
 
@@ -131,8 +137,8 @@ function insertResults(results) {
         let name = crate.name;
         let url = crate.url;
         let res = jsonCrateResToCss(crate.res);
-        let run1 = parseRunResult(crate.runs[0]);
-        let run2 = parseRunResult(crate.runs[1]);
+        let run1 = parseRunResult(crate.res, crate.runs[0]);
+        let run2 = parseRunResult(crate.res, crate.runs[1]);
 
         function runToHtml(run) {
             if (run.log) {
@@ -163,46 +169,50 @@ function insertResults(results) {
 
 function jsonCrateResToCss(res) {
     if (res == "Regressed") {
-	return "regressed";
+        return "regressed";
     } else if (res == "Fixed") {
-	return "fixed";
+        return "fixed";
     } else if (res == "Unknown") {
-	return "unknown";
+        return "unknown";
     } else if (res == "SameBuildFail") {
-	return "same-build-fail";
+        return "same-build-fail";
     } else if (res == "SameTestFail") {
-	return "same-test-fail";
+        return "same-test-fail";
     } else if (res == "SameTestPass") {
-	return "same-test-pass";
+        return "same-test-pass";
+    } else if (res == "Skipped") {
+        return "skipped";
     } else {
-	throw "unknown test status";
+        throw "unknown test status";
     }
 }
 
-function parseRunResult(res) {
+function parseRunResult(crate_res, res) {
+    let log, result;
     if (res == null) {
-	return {
-	    res: "unknown",
-	    log: null
-	};
+        log = null;
+        if (crate_res == "Skipped") {
+            result = "skipped";
+        } else {
+            result = "unknown";
+        }
     } else {
-	return {
-	    res: jsonRunResToDisplay(res.res),
-	    log: res.log
-	};
+        log = res.log;
+        if (res.res == "BuildFail") {
+            result = "build-fail";
+        } else if (res.res == "TestFail") {
+            result =  "test-fail";
+        } else if (res.res == "TestPass") {
+            result = "test-pass";
+        } else {
+            throw "unknown test status";
+        }
     }
-}
 
-function jsonRunResToDisplay(res) {
-    if (res == "BuildFail") {
-	return "build-fail";
-    } else if (res == "TestFail") {
-	return "test-fail";
-    } else if (res == "TestPass") {
-	return "test-pass";
-    } else {
-	throw "unknown test status";
-    }
+    return {
+        res: result,
+        log: log,
+    };
 }
 
 function setUpButtons() {

--- a/template/report.html
+++ b/template/report.html
@@ -36,6 +36,10 @@ results_url = "{{results_url}}"
     fixed
     <span class="count"></span>
   </span>
+  <span id="c-skipped" class="skipped">
+    skipped
+    <span class="count"></span>
+  </span>
   <span id="c-unknown" class="unknown">
     unknown
     <span class="count"></span>

--- a/template/report.html
+++ b/template/report.html
@@ -53,6 +53,10 @@ results_url = "{{results_url}}"
     test-fail
     <span class="count"></span>
   </span>
+  <span id="c-same-test-skipped" class="same-test-skipped">
+    test-skipped
+    <span class="count"></span>
+  </span>
   <span id="c-same-test-pass" class="same-test-pass">
     test-pass
     <span class="count"></span>


### PR DESCRIPTION
This PR adds two new sections to the generated report:

* `skipped`: both build and tests were skipped (because of the blacklist)
* `test-skipped`: build completed successfully but tests didn't run (either because of the blacklist or build-only crater runs)

Part of #186.

![screenshot from 2018-02-28 14-28-38](https://user-images.githubusercontent.com/2299951/36790011-b0237374-1c93-11e8-91e5-bcd3c1ff9ff6.png)