### PR TITLE
Avoid preparing skipped crates

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -206,8 +206,8 @@ impl Crater {
             }
             Crater::PrepareEx { ref ex } => {
                 let ex = ex::Experiment::load(&ex.0)?;
-                ex.prepare_shared()?;
-                ex.prepare_local()?;
+                ex.prepare_shared(&config)?;
+                ex.prepare_local(&config)?;
             }
             Crater::CopyEx { ref ex1, ref ex2 } => {
                 ex::copy(&ex1.0, &ex2.0)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,12 +127,12 @@ mod tests {
         assert!(list.is_quiet(&ExCrate::Repo {
             org: "rust-lang".into(),
             name: "rust".into(),
-            sha: "0".into(),
+            sha: None,
         }));
         assert!(!list.is_quiet(&ExCrate::Repo {
             org: "rust-lang".into(),
             name: "cargo".into(),
-            sha: "0".into(),
+            sha: None,
         }));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
 use errors::*;
 use ex::ExCrate;
+use gh_mirrors;
+use lists::Crate;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
@@ -21,6 +23,41 @@ fn default_false() -> bool {
     false
 }
 
+pub enum CrateDetails<'a> {
+    Version(&'a str),
+    GitHubRepo(&'a str, &'a str),
+}
+
+pub trait GetDetails {
+    fn get_details(&self) -> Option<CrateDetails>;
+}
+
+impl GetDetails for ExCrate {
+    fn get_details(&self) -> Option<CrateDetails> {
+        match *self {
+            ExCrate::Version { ref name, .. } => Some(CrateDetails::Version(name)),
+            ExCrate::Repo {
+                ref org, ref name, ..
+            } => Some(CrateDetails::GitHubRepo(org, name)),
+        }
+    }
+}
+
+impl GetDetails for Crate {
+    fn get_details(&self) -> Option<CrateDetails> {
+        match *self {
+            Crate::Version { ref name, .. } => Some(CrateDetails::Version(name)),
+            Crate::Repo { ref url } => {
+                if let Ok((org, name)) = gh_mirrors::gh_url_to_org_and_name(url) {
+                    Some(CrateDetails::GitHubRepo(org, name))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
@@ -36,28 +73,27 @@ impl Config {
         Ok(::toml::from_str(&buffer)?)
     }
 
-    fn crate_config(&self, ex: &ExCrate) -> Option<&CrateConfig> {
-        match *ex {
-            ExCrate::Version { ref name, .. } => self.crates.get(name),
-            ExCrate::Repo {
-                ref org, ref name, ..
-            } => {
+    fn crate_config<C: GetDetails>(&self, c: &C) -> Option<&CrateConfig> {
+        match c.get_details() {
+            Some(CrateDetails::Version(name)) => self.crates.get(name),
+            Some(CrateDetails::GitHubRepo(org, name)) => {
                 let repo_name = format!("{}/{}", org, name);
                 self.github_repos.get(&repo_name)
             }
+            None => None,
         }
     }
 
-    pub fn should_skip(&self, ex: &ExCrate) -> bool {
-        self.crate_config(ex).map(|c| c.skip).unwrap_or(false)
+    pub fn should_skip<C: GetDetails>(&self, c: &C) -> bool {
+        self.crate_config(c).map(|c| c.skip).unwrap_or(false)
     }
 
-    pub fn should_skip_tests(&self, ex: &ExCrate) -> bool {
-        self.crate_config(ex).map(|c| c.skip_tests).unwrap_or(false)
+    pub fn should_skip_tests<C: GetDetails>(&self, c: &C) -> bool {
+        self.crate_config(c).map(|c| c.skip_tests).unwrap_or(false)
     }
 
-    pub fn is_quiet(&self, ex: &ExCrate) -> bool {
-        self.crate_config(ex).map(|c| c.quiet).unwrap_or(false)
+    pub fn is_quiet<C: GetDetails>(&self, c: &C) -> bool {
+        self.crate_config(c).map(|c| c.quiet).unwrap_or(false)
     }
 }
 

--- a/src/ex.rs
+++ b/src/ex.rs
@@ -307,8 +307,8 @@ impl FromStr for ExCrate {
                 let sha = &s[hash_idx + 1..];
                 let (org, name) = gh_mirrors::gh_url_to_org_and_name(repo)?;
                 Ok(ExCrate::Repo {
-                    org,
-                    name,
+                    org: org.to_string(),
+                    name: name.to_string(),
                     sha: sha.to_string(),
                 })
             } else {

--- a/src/ex_run.rs
+++ b/src/ex_run.rs
@@ -43,7 +43,7 @@ fn run_exts(ex: &Experiment, tcs: &[Toolchain], config: &Config) -> Result<()> {
     let db = FileDB::for_experiment(ex);
     verify_toolchains(ex, tcs)?;
 
-    let crates = ex.crates()?;
+    let crates = ex.crates(config)?;
 
     // Just for reporting progress
     let total_crates = crates.len() * tcs.len();

--- a/src/gh_mirrors.rs
+++ b/src/gh_mirrors.rs
@@ -8,17 +8,16 @@ pub fn repo_dir(url: &str) -> Result<PathBuf> {
     Ok(GH_MIRRORS_DIR.join(format!("{}.{}", org, name)))
 }
 
-pub fn gh_url_to_org_and_name(url: &str) -> Result<(String, String)> {
+pub fn gh_url_to_org_and_name(url: &str) -> Result<(&str, &str)> {
     let mut components = url.split('/').collect::<Vec<_>>();
     let name = components.pop();
     let org = components.pop();
-    let (org, name) = if let (Some(org), Some(name)) = (org, name) {
-        (org, name)
+
+    if let (Some(org), Some(name)) = (org, name) {
+        Ok((org, name))
     } else {
         bail!("malformed repo url: {}", url);
-    };
-
-    Ok((org.to_string(), name.to_string()))
+    }
 }
 
 pub fn fetch(url: &str) -> Result<()> {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -336,8 +336,8 @@ impl Crate {
             Crate::Repo { ref url } => if let Some(sha) = shas.get(url) {
                 let (org, name) = gh_mirrors::gh_url_to_org_and_name(url)?;
                 Ok(ExCrate::Repo {
-                    org,
-                    name,
+                    org: org.to_string(),
+                    name: name.to_string(),
                     sha: sha.to_string(),
                 })
             } else {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -51,7 +51,7 @@ pub fn generate_report(config: &Config, ex: &ex::Experiment) -> Result<TestResul
     let db = FileDB::for_experiment(ex);
     assert_eq!(ex.toolchains.len(), 2);
 
-    let res = ex.crates()?
+    let res = ex.crates(config)?
         .into_iter()
         .map(|krate| {
             // Any errors here will turn into unknown results
@@ -89,7 +89,7 @@ const PROGRESS_FRACTION: usize = 10; // write progress every ~1/N crates
 
 fn write_logs<W: ReportWriter>(ex: &ex::Experiment, dest: &W, config: &Config) -> Result<()> {
     let db = FileDB::for_experiment(ex);
-    let crates = ex.crates()?;
+    let crates = ex.crates(config)?;
     let num_crates = crates.len();
     let progress_every = (num_crates / PROGRESS_FRACTION) + 1;
     for (i, krate) in crates.into_iter().enumerate() {
@@ -158,7 +158,11 @@ fn crate_to_name(c: &ex::ExCrate) -> String {
             ref org,
             ref name,
             ref sha,
-        } => format!("{}.{}.{}", org, name, sha),
+        } => if let Some(ref sha) = *sha {
+            format!("{}.{}.{}", org, name, sha)
+        } else {
+            format!("{}.{}", org, name)
+        },
     }
 }
 
@@ -172,7 +176,11 @@ fn crate_to_url(c: &ex::ExCrate) -> String {
             ref org,
             ref name,
             ref sha,
-        } => format!("https://github.com/{}/{}/tree/{}", org, name, sha),
+        } => if let Some(ref sha) = *sha {
+            format!("https://github.com/{}/{}/tree/{}", org, name, sha)
+        } else {
+            format!("https://github.com/{}/{}", org, name)
+        },
     }
 }
 

--- a/src/results.rs
+++ b/src/results.rs
@@ -41,7 +41,11 @@ fn crate_to_dir(c: &ExCrate) -> String {
             ref org,
             ref name,
             ref sha,
-        } => format!("gh/{}.{}.{}", org, name, sha),
+        } => if let Some(ref sha) = *sha {
+            format!("gh/{}.{}.{}", org, name, sha)
+        } else {
+            format!("gh/{}.{}", org, name)
+        },
     }
 }
 


### PR DESCRIPTION
In the original blacklist PR, skipped crates were not executed, but they were still prepared, wasting time. This PR also skips them when executing `prepare-ex`.

Part of #186