### PR TITLE
Fix test suites' build failures not reported

### DIFF
--- a/src/ex_run.rs
+++ b/src/ex_run.rs
@@ -181,24 +181,21 @@ fn verify_toolchains(config: &Experiment, tcs: &[Toolchain]) -> Result<()> {
 }
 
 fn build(ex: &Experiment, source_path: &Path, toolchain: &Toolchain, quiet: bool) -> Result<()> {
-    toolchain
-        .run_cargo(
-            &ex.name,
-            source_path,
-            &["build", "--frozen"],
-            CargoState::Locked,
-            quiet,
-        )
-        .map(|_| {
-            toolchain.run_cargo(
-                &ex.name,
-                source_path,
-                &["test", "--frozen", "--no-run"],
-                CargoState::Locked,
-                quiet,
-            )
-        })
-        .map(|_| ())
+    toolchain.run_cargo(
+        &ex.name,
+        source_path,
+        &["build", "--frozen"],
+        CargoState::Locked,
+        quiet,
+    )?;
+    toolchain.run_cargo(
+        &ex.name,
+        source_path,
+        &["test", "--frozen", "--no-run"],
+        CargoState::Locked,
+        quiet,
+    )?;
+    Ok(())
 }
 
 fn test_build_and_test(


### PR DESCRIPTION
While testing the new blacklist in #186 the "accel" crate was marked as test-skipped even if building the tests failed. Turns out this was a bug introduced before the blacklist PR.

In the implementation there are two stages: "build" and "test". The "build" stage builds both the crate and the tests (without running them), and then the "test" stage runs the tests built in the previous stage. The old code didn't check for build failures of the tests in the "build" stage though, but that didn't matter since the "test" stage was missing the build artifacts and tried to rebuild them, failing again.

However, `skip-tests` crates don't execute the "test" stage anymore, so test build failures were ignored for those crates. This PR fixes this by checking for failures in the "build" stage.