### PR TITLE
Move demo crates list to config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,12 @@
-# This file allows to customize how crater treats specific crates/repos
+# This section contains the list of tested crates when defining an experiment
+# with `--crate-select demo`.
+
+[demo-crates]
+crates = ["lazy_static"]
+github-repos = ["brson/hello-rs"]
+
+
+# These sections allows to customize how crater treats specific crates/repos
 #
 # The available options for each crate/repo are:
 #  - skip       (bool): ignore this crate/repo
@@ -7,7 +15,6 @@
 #
 # Please add a comment along with each entry explaining the reasons of the
 # changes, thanks!
-
 
 [crates]
 # crate_name = { option = true }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -197,12 +197,15 @@ impl Crater {
                 ref mode,
                 ref crates,
             } => {
-                ex::define(ex::ExOpts {
-                    name: ex.0.clone(),
-                    toolchains: vec![tc1.clone(), tc2.clone()],
-                    mode: mode.clone(),
-                    crates: crates.clone(),
-                })?;
+                ex::define(
+                    ex::ExOpts {
+                        name: ex.0.clone(),
+                        toolchains: vec![tc1.clone(), tc2.clone()],
+                        mode: mode.clone(),
+                        crates: crates.clone(),
+                    },
+                    &config,
+                )?;
             }
             Crater::PrepareEx { ref ex } => {
                 let ex = ex::Experiment::load(&ex.0)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,15 @@ fn default_false() -> bool {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case")]
+pub struct DemoCrates {
+    pub crates: Vec<String>,
+    pub github_repos: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Config {
+    demo_crates: DemoCrates,
     crates: HashMap<String, CrateConfig>,
     github_repos: HashMap<String, CrateConfig>,
 }
@@ -59,6 +67,10 @@ impl Config {
     pub fn is_quiet(&self, ex: &ExCrate) -> bool {
         self.crate_config(ex).map(|c| c.quiet).unwrap_or(false)
     }
+
+    pub fn demo_crates(&self) -> &DemoCrates {
+        &self.demo_crates
+    }
 }
 
 #[cfg(test)]
@@ -70,6 +82,9 @@ mod tests {
     fn test_config() {
         // A sample config file loaded from memory
         let config = concat!(
+            "[demo-crates]\n",
+            "crates = []\n",
+            "github-repos = []\n",
             "[crates]\n",
             "lazy_static = { skip = true }\n",
             "\n",


### PR DESCRIPTION
This is a small change, but it will help when debugging why a crate doesn't behave correctly (it makes possible to add a new crate to the demo set without recompiling crater).