### PR TITLE
The great Travis speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,24 +29,22 @@ matrix:
   allow_failures:
     - rust: nightly
 
-before_script:
-  - export PATH=$HOME/.cargo/bin:$PATH
-  - |
-    if [[ $TASK = "lint" ]]; then
-        if ! type -p cargo-install-update; then
-            cargo install --force cargo-update
-        else
-            cargo install-update -i cargo-update
-        fi
+before_script: |
+  if [[ $TASK = "lint" ]]; then
+      if ! type -p cargo-install-update; then
+          cargo install --force cargo-update
+      else
+          cargo install-update -i cargo-update
+      fi
 
-        rustup component add rustfmt-preview
-        cargo install-update -i "clippy:$CLIPPY_VERSION"
-    fi
-script:
-  - |
-    if [[ $TASK = "lint" ]]; then
-        cargo fmt -- --write-mode diff
-        cargo clippy
-    elif [[ $TASK = "test" ]]; then
-        cargo build && cargo test
-    fi
+      rustup component add rustfmt-preview
+      cargo install-update -i "clippy:$CLIPPY_VERSION"
+  fi
+
+script: |
+  if [[ $TASK = "lint" ]]; then
+      cargo fmt -- --write-mode diff
+      cargo clippy
+  elif [[ $TASK = "test" ]]; then
+      cargo build && cargo test
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rust:
 
 env:
   global:
+    - RUSTFLAGS=-Dwarnings
     # Versions known to work with pinned nightly.
     - CLIPPY_VERSION=0.0.180
     - RUSTFMT_VERSION=0.3.6
@@ -26,10 +27,8 @@ before_script:
         cargo install-update -i "rustfmt-nightly:$RUSTFMT_VERSION"
     fi
 script:
+  - cargo build && cargo test
   - |
-    RUSTFLAGS=-Dwarnings cargo build &&
-    cargo test
+    [[ ! $TRAVIS_RUST_VERSION =~ nightly-* ]] || cargo fmt -- --write-mode diff
   - |
-    [[ ! $TRAVIS_RUST_VERSION =~ nightly-* ]] || RUSTFLAGS=-Dwarnings cargo fmt -- --write-mode diff
-  - |
-    [[ ! $TRAVIS_RUST_VERSION =~ nightly-* ]] || RUSTFLAGS=-Dwarnings cargo clippy
+    [[ ! $TRAVIS_RUST_VERSION =~ nightly-* ]] || cargo clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,52 @@
 sudo: false
 dist: trusty
+
 language: rust
 cache: cargo
-rust:
-  - stable
-  - nightly-2018-01-20
 
 env:
   global:
     - RUSTFLAGS=-Dwarnings
-    # Versions known to work with pinned nightly.
+    # Versions known to work with pinned nightly for lints.
     - CLIPPY_VERSION=0.0.180
+
+matrix:
+  include:
+    # Tests on all the channels
+    - env: TASK=test
+      rust: stable
+    - env: TASK=test
+      rust: beta
+    - env: TASK=test
+      rust: nightly
+
+    # Execute lints with the pinned nightly we know works.
+    - env: TASK=lint
+      rust: nightly-2018-01-20
+
+  # Don't block CI if a nightly is faulty
+  fast_finish: true
+  allow_failures:
+    - rust: nightly
 
 before_script:
   - export PATH=$HOME/.cargo/bin:$PATH
   - |
-    if ! type -p cargo-install-update; then
-        cargo install --force cargo-update
-    else
-        cargo install-update -i cargo-update
-    fi
-  - |
-    if [[  $TRAVIS_RUST_VERSION =~ nightly-* ]]; then
+    if [[ $TASK = "lint" ]]; then
+        if ! type -p cargo-install-update; then
+            cargo install --force cargo-update
+        else
+            cargo install-update -i cargo-update
+        fi
+
         rustup component add rustfmt-preview
         cargo install-update -i "clippy:$CLIPPY_VERSION"
     fi
 script:
   - |
-    [[ ! $TRAVIS_RUST_VERSION =~ nightly-* ]] || cargo fmt -- --write-mode diff
-  - cargo build && cargo test
-  - |
-    [[ ! $TRAVIS_RUST_VERSION =~ nightly-* ]] || cargo clippy
+    if [[ $TASK = "lint" ]]; then
+        cargo fmt -- --write-mode diff
+        cargo clippy
+    elif [[ $TASK = "test" ]]; then
+        cargo build && cargo test
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ cache: cargo
 env:
   global:
     - RUSTFLAGS=-Dwarnings
+
     # Versions known to work with pinned nightly for lints.
-    - CLIPPY_VERSION=0.0.180
+    - CLIPPY_VERSION=0.0.187
 
 matrix:
   include:
@@ -22,7 +23,7 @@ matrix:
 
     # Execute lints with the pinned nightly we know works.
     - env: TASK=lint
-      rust: nightly-2018-01-20
+      rust: nightly-2018-03-07
 
   # Don't block CI if a nightly is faulty
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - RUSTFLAGS=-Dwarnings
     # Versions known to work with pinned nightly.
     - CLIPPY_VERSION=0.0.180
-    - RUSTFMT_VERSION=0.3.6
 
 before_script:
   - export PATH=$HOME/.cargo/bin:$PATH
@@ -23,12 +22,12 @@ before_script:
     fi
   - |
     if [[  $TRAVIS_RUST_VERSION =~ nightly-* ]]; then
+        rustup component add rustfmt-preview
         cargo install-update -i "clippy:$CLIPPY_VERSION"
-        cargo install-update -i "rustfmt-nightly:$RUSTFMT_VERSION"
     fi
 script:
-  - cargo build && cargo test
   - |
     [[ ! $TRAVIS_RUST_VERSION =~ nightly-* ]] || cargo fmt -- --write-mode diff
+  - cargo build && cargo test
   - |
     [[ ! $TRAVIS_RUST_VERSION =~ nightly-* ]] || cargo clippy

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,8 @@ pub enum Crater {
         env: DockerEnv,
     },
 
-    #[structopt(name = "create-lists", about = "create all the lists of crates")] CreateLists,
+    #[structopt(name = "create-lists", about = "create all the lists of crates")]
+    CreateLists,
 
     #[structopt(name = "define-ex", about = "define an experiment")]
     DefineEx {
@@ -107,10 +108,7 @@ pub enum Crater {
     },
 
     #[structopt(name = "copy-ex", about = "copy all data from one experiment to another")]
-    CopyEx {
-        ex1: Ex,
-        ex2: Ex,
-    },
+    CopyEx { ex1: Ex, ex2: Ex },
 
     #[structopt(name = "delete-ex", about = "delete shared data for experiment")]
     DeleteEx {
@@ -174,7 +172,8 @@ pub enum Crater {
         s3_prefix: Option<report::S3Prefix>,
     },
 
-    #[structopt(name = "serve-report", about = "serve report")] Serve,
+    #[structopt(name = "serve-report", about = "serve report")]
+    Serve,
 }
 
 impl Crater {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -104,8 +104,8 @@ pub fn rust_container(config: RustEnv) -> ContainerConfig {
 
     ContainerConfig {
         image_name: IMAGE_NAME,
-        mounts: mounts,
-        env: env,
+        mounts,
+        env,
     }
 }
 

--- a/src/ex.rs
+++ b/src/ex.rs
@@ -136,9 +136,9 @@ pub fn define_(ex_name: &str, tcs: Vec<Toolchain>, crates: Vec<Crate>, mode: ExM
     );
     let ex = Experiment {
         name: ex_name.to_string(),
-        crates: crates,
+        crates,
         toolchains: tcs,
-        mode: mode,
+        mode,
     };
     fs::create_dir_all(&ex_dir(&ex.name))?;
     let json = serde_json::to_string(&ex)?;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -63,7 +63,7 @@ pub fn generate_report(config: &Config, ex: &ex::Experiment) -> Result<TestResul
                 let rel_log = writer.result_path_fragement();
 
                 Ok(BuildTestResult {
-                    res: res,
+                    res,
                     log: format!("{}", rel_log.display()),
                 })
             });

--- a/src/run.rs
+++ b/src/run.rs
@@ -212,9 +212,9 @@ fn log_command(mut cmd: Command, capture: bool, quiet: bool) -> Result<ProcessOu
     }))?;
 
     Ok(ProcessOutput {
-        status: status,
-        stdout: stdout,
-        stderr: stderr,
+        status,
+        stdout,
+        stderr,
     })
 }
 


### PR DESCRIPTION
**Important: all the Travis caches needs to be cleaned before merging this**. The old stable cache is broken as far as I understand, and the migration to rustfmt-preview may cause problems to the lints job. Anyone with push access to this repo can do it on [this page](https://travis-ci.org/rust-lang-nursery/crater/caches), with the "delete all repository caches" button.

---

Travis speed on this repository is pretty bad (not rustc-bad, but a simple commit takes more than 20 minutes to test), and with this PR I'm trying to solve that. There are a few problems at the moment:

1. Travis rebuilds *all the dependencies* two times on each build, since the `build`/`clippy` step is done with `RUSTFLAGS=-Dwarnings` and the `test` one without
2. Only the stable channel is actually tested: the beta one is missing, and the nightly one is pinned to a specific date (thanks clippy!)
3. The "lints job" uses a pinned version of rustfmt, so we need to check if it works every time we bump the pinned nightly: now that the rustfmt-preview component is available we can use it instead
4. The pinned nightly (and so rustfmt/clippy) is a bit old, so the latest versions of the tools I use locally produce different output than CI

This PR addresses those problems:

1. All the cargo calls now are done with `RUSTFLAGS=-Dwarnings`, so it doesn't invalidate all the cached dependencies multiple times on each build
2. I added a build job for beta and nightly (different than the one used for lints), and I allowed the nightly one to fail without failing the build (I don't want to block CI if there is a regression)
3. Switched to using rustfmt-preview on the "nightly lints" job: I'm not doing it everywhere because rustfmt stable wants different things than rustfmt nightly at the moment
4. Updated the pinned nightly and clippy to the latest _working_ version (there are regressions affecting us in both the nightlies of [clippy 0.0.188](https://github.com/rust-lang/rust/issues/49081) and of [clippy 0.0.189](https://github.com/rust-lang/rust/pull/48986#issuecomment-374094440))

I have to say, the result of this is really good (we go from a 20+ minutes wait to about 3 minutes):

| | [Old builds](https://travis-ci.org/rust-lang-nursery/crater/builds/355764877) | [New builds without cache](https://travis-ci.org/pietroalbini/crater/builds/356050778) | [New builds](https://travis-ci.org/pietroalbini/crater/builds/356062156) |
|-|-|-|-|
| stable | 18 min | 9 min | 3 min |
| beta | _[not tested]_ | 9 min | 3 min |
| nightly | _[not tested]_ | 9 min | 3 min |
| nightly lints | 22 min | 21 min | 3 min |