### PR TITLE
Fix wrong shas.json position

### DIFF
--- a/src/results.rs
+++ b/src/results.rs
@@ -58,7 +58,7 @@ pub struct FileDB {
 
 impl FileDB {
     fn shafile_path(&self, ex: &Experiment) -> PathBuf {
-        ex_dir(&ex.name).join("res").join("shas.json")
+        ex_dir(&ex.name).join("shas.json")
     }
 
     fn result_dir(&self, ex: &Experiment, toolchain: &Toolchain, krate: &Crate) -> PathBuf {


### PR DESCRIPTION
The other path I was using before this PR (`work/ex/NAME/res/shas.json`) does not work with the legacy prepare-ex/run-tc workflow, since that directory is deleted after the file is created... Woops.