### PR TITLE
Add tests for report generation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,11 +12,11 @@ static CONFIG_FILE: &'static str = "config.toml";
 #[serde(rename_all = "kebab-case")]
 pub struct CrateConfig {
     #[serde(default = "default_false")]
-    skip: bool,
+    pub skip: bool,
     #[serde(default = "default_false")]
-    skip_tests: bool,
+    pub skip_tests: bool,
     #[serde(default = "default_false")]
-    quiet: bool,
+    pub quiet: bool,
 }
 
 fn default_false() -> bool {
@@ -49,9 +49,9 @@ pub struct DemoCrates {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
-    demo_crates: DemoCrates,
-    crates: HashMap<String, CrateConfig>,
-    github_repos: HashMap<String, CrateConfig>,
+    pub demo_crates: DemoCrates,
+    pub crates: HashMap<String, CrateConfig>,
+    pub github_repos: HashMap<String, CrateConfig>,
     pub server: ServerConfig,
 }
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -8,6 +8,8 @@ use mime::{self, Mime};
 use results::{ReadResults, TestResult};
 use serde_json;
 use std::borrow::Cow;
+#[cfg(test)]
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::AsRef;
 use std::fmt::{self, Display};
@@ -33,7 +35,7 @@ struct CrateResult {
     runs: [Option<BuildTestResult>; 2],
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 enum Comparison {
     Regressed,
     Fixed,
@@ -315,5 +317,274 @@ impl ReportWriter for FileWriter {
 impl Display for FileWriter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.display().fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config::{Config, CrateConfig};
+    use crates::{Crate, GitHubRepo, RegistryCrate};
+    use ex::{ExCapLints, ExMode, Experiment};
+    use results::{DummyDB, TestResult};
+    use std::collections::HashMap;
+    use toolchain::Toolchain;
+
+    #[derive(Default)]
+    pub struct DummyWriter {
+        results: RefCell<HashMap<(PathBuf, Mime), Vec<u8>>>,
+    }
+
+    impl DummyWriter {
+        pub fn get<P: AsRef<Path>>(&self, path: P, mime: &Mime) -> Vec<u8> {
+            self.results
+                .borrow()
+                .get(&(path.as_ref().to_path_buf(), mime.clone()))
+                .unwrap()
+                .clone()
+        }
+    }
+
+    impl ReportWriter for DummyWriter {
+        fn write_bytes<P: AsRef<Path>>(&self, path: P, b: Vec<u8>, mime: &Mime) -> Result<()> {
+            self.results
+                .borrow_mut()
+                .insert((path.as_ref().to_path_buf(), mime.clone()), b);
+            Ok(())
+        }
+
+        fn write_string<P: AsRef<Path>>(&self, path: P, s: Cow<str>, mime: &Mime) -> Result<()> {
+            self.results.borrow_mut().insert(
+                (path.as_ref().to_path_buf(), mime.clone()),
+                s.bytes().collect(),
+            );
+            Ok(())
+        }
+
+        fn copy<P: AsRef<Path>, R: Read>(&self, r: &mut R, path: P, mime: &Mime) -> Result<()> {
+            let mut buffer = Vec::new();
+            r.read_to_end(&mut buffer)?;
+
+            self.results
+                .borrow_mut()
+                .insert((path.as_ref().to_path_buf(), mime.clone()), buffer);
+            Ok(())
+        }
+    }
+
+    impl Display for DummyWriter {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, ":dummy:")
+        }
+    }
+
+    #[test]
+    fn test_crate_to_path_fragment() {
+        let tc = Toolchain::Dist("stable".into());
+        let reg = Crate::Registry(RegistryCrate {
+            name: "lazy_static".into(),
+            version: "1.0".into(),
+        });
+        let gh = Crate::GitHub(GitHubRepo {
+            org: "brson".into(),
+            name: "hello-rs".into(),
+        });
+
+        assert_eq!(
+            crate_to_path_fragment(&tc, &reg),
+            PathBuf::from("stable/reg/lazy_static-1.0")
+        );
+        assert_eq!(
+            crate_to_path_fragment(&tc, &gh),
+            PathBuf::from("stable/gh/brson.hello-rs")
+        );
+    }
+
+    #[test]
+    fn test_crate_to_name() {
+        let reg = Crate::Registry(RegistryCrate {
+            name: "lazy_static".into(),
+            version: "1.0".into(),
+        });
+        let repo = GitHubRepo {
+            org: "brson".into(),
+            name: "hello-rs".into(),
+        };
+        let gh = Crate::GitHub(repo.clone());
+
+        let mut shas = HashMap::new();
+        shas.insert(repo, "f00".into());
+
+        assert_eq!(
+            crate_to_name(&reg, &shas).unwrap(),
+            "lazy_static-1.0".to_string()
+        );
+        assert_eq!(
+            crate_to_name(&gh, &shas).unwrap(),
+            "brson.hello-rs.f00".to_string()
+        );
+    }
+
+    #[test]
+    fn test_crate_to_url() {
+        let reg = Crate::Registry(RegistryCrate {
+            name: "lazy_static".into(),
+            version: "1.0".into(),
+        });
+        let repo = GitHubRepo {
+            org: "brson".into(),
+            name: "hello-rs".into(),
+        };
+        let gh = Crate::GitHub(repo.clone());
+
+        let mut shas = HashMap::new();
+        shas.insert(repo, "f00".into());
+
+        assert_eq!(
+            crate_to_url(&reg, &shas).unwrap(),
+            "https://crates.io/crates/lazy_static/1.0".to_string()
+        );
+        assert_eq!(
+            crate_to_url(&gh, &shas).unwrap(),
+            "https://github.com/brson/hello-rs/tree/f00".to_string()
+        );
+    }
+
+    #[test]
+    fn test_compare() {
+        macro_rules! test_compare {
+            ($cmp:ident, $config:expr, $reg:expr, [$($a:ident + $b:ident = $c:ident,)*]) => {
+                $(
+                    assert_eq!(
+                        $cmp(
+                            $config,
+                            $reg,
+                            &Some(BuildTestResult {
+                                res: TestResult::$a,
+                                log: String::with_capacity(0),
+                            }),
+                            &Some(BuildTestResult {
+                                res: TestResult::$b,
+                                log: String::with_capacity(0),
+                            }),
+                        ),
+                        Comparison::$c
+                    );
+                )*
+            }
+        }
+
+        let mut config = Config::default();
+        let reg = Crate::Registry(RegistryCrate {
+            name: "lazy_static".into(),
+            version: "1.0".into(),
+        });
+
+        test_compare!(
+            compare,
+            &config,
+            &reg,
+            [
+                BuildFail + BuildFail = SameBuildFail,
+                TestFail + TestFail = SameTestFail,
+                TestSkipped + TestSkipped = SameTestSkipped,
+                TestPass + TestPass = SameTestPass,
+                BuildFail + TestFail = Fixed,
+                BuildFail + TestSkipped = Fixed,
+                BuildFail + TestPass = Fixed,
+                TestFail + TestPass = Fixed,
+                TestPass + TestFail = Regressed,
+                TestPass + BuildFail = Regressed,
+                TestSkipped + BuildFail = Regressed,
+                TestFail + BuildFail = Regressed,
+            ]
+        );
+
+        assert_eq!(compare(&config, &reg, &None, &None), Comparison::Unknown);
+
+        config.crates.insert(
+            "lazy_static".into(),
+            CrateConfig {
+                skip: true,
+                skip_tests: false,
+                quiet: false,
+            },
+        );
+        assert_eq!(compare(&config, &reg, &None, &None), Comparison::Skipped);
+    }
+
+    #[test]
+    fn test_report_generation() {
+        let config = Config::default();
+
+        let repo = GitHubRepo {
+            org: "brson".into(),
+            name: "hello-rs".into(),
+        };
+        let gh = Crate::GitHub(repo.clone());
+
+        let stable = Toolchain::Dist("stable".to_string());
+        let beta = Toolchain::Dist("beta".to_string());
+
+        let ex = Experiment {
+            name: "foo".to_string(),
+            crates: vec![gh.clone()],
+            toolchains: vec![stable.clone(), beta.clone()],
+            mode: ExMode::BuildAndTest,
+            cap_lints: ExCapLints::Forbid,
+        };
+
+        let mut db = DummyDB::default();
+        db.add_dummy_sha(&ex, repo.clone(), "f00".to_string());
+        db.add_dummy_result(&ex, gh.clone(), stable.clone(), TestResult::TestPass);
+        db.add_dummy_result(&ex, gh.clone(), beta.clone(), TestResult::BuildFail);
+        db.add_dummy_log(&ex, gh.clone(), stable.clone(), b"stable log".to_vec());
+        db.add_dummy_log(&ex, gh.clone(), beta.clone(), b"beta log".to_vec());
+
+        let writer = DummyWriter::default();
+        gen(&db, &ex, &writer, &config).unwrap();
+
+        assert_eq!(
+            writer.get("config.json", &mime::APPLICATION_JSON),
+            serde_json::to_vec(&ex).unwrap()
+        );
+
+        assert_eq!(
+            &writer.get("stable/gh/brson.hello-rs/log.txt", &mime::TEXT_PLAIN_UTF_8),
+            b"stable log"
+        );
+        assert_eq!(
+            &writer.get("beta/gh/brson.hello-rs/log.txt", &mime::TEXT_PLAIN_UTF_8),
+            b"beta log"
+        );
+
+        let result: TestResults =
+            serde_json::from_slice(&writer.get("results.json", &mime::APPLICATION_JSON)).unwrap();
+
+        assert_eq!(result.crates.len(), 1);
+        let crate_result = &result.crates[0];
+
+        assert_eq!(crate_result.name.as_str(), "brson.hello-rs.f00");
+        assert_eq!(
+            crate_result.url.as_str(),
+            "https://github.com/brson/hello-rs/tree/f00"
+        );
+        assert_eq!(crate_result.res, Comparison::Regressed);
+        assert_eq!(
+            (&crate_result.runs[0]).as_ref().unwrap().res,
+            TestResult::TestPass
+        );
+        assert_eq!(
+            (&crate_result.runs[1]).as_ref().unwrap().res,
+            TestResult::BuildFail
+        );
+        assert_eq!(
+            (&crate_result.runs[0]).as_ref().unwrap().log.as_str(),
+            "stable/gh/brson.hello-rs"
+        );
+        assert_eq!(
+            (&crate_result.runs[1]).as_ref().unwrap().log.as_str(),
+            "beta/gh/brson.hello-rs"
+        );
     }
 }

--- a/src/results/dummy.rs
+++ b/src/results/dummy.rs
@@ -1,0 +1,86 @@
+use crates::{Crate, GitHubRepo};
+use errors::*;
+use ex::Experiment;
+use results::{ReadResults, TestResult};
+use std::collections::HashMap;
+use toolchain::Toolchain;
+
+#[derive(Default)]
+struct DummyData {
+    shas: HashMap<GitHubRepo, String>,
+    logs: HashMap<(Crate, Toolchain), Vec<u8>>,
+    results: HashMap<(Crate, Toolchain), TestResult>,
+}
+
+#[derive(Default)]
+pub struct DummyDB {
+    experiments: HashMap<String, DummyData>,
+}
+
+impl DummyDB {
+    fn get_data(&self, ex: &Experiment) -> Result<&DummyData> {
+        Ok(self.experiments
+            .get(&ex.name)
+            .ok_or_else(|| format!("missing experiment {}", ex.name))?)
+    }
+
+    pub fn add_dummy_sha(&mut self, ex: &Experiment, repo: GitHubRepo, sha: String) {
+        self.experiments
+            .entry(ex.name.to_string())
+            .or_insert_with(DummyData::default)
+            .shas
+            .insert(repo, sha);
+    }
+
+    pub fn add_dummy_log(&mut self, ex: &Experiment, krate: Crate, tc: Toolchain, log: Vec<u8>) {
+        self.experiments
+            .entry(ex.name.to_string())
+            .or_insert_with(DummyData::default)
+            .logs
+            .insert((krate, tc), log);
+    }
+
+    pub fn add_dummy_result(
+        &mut self,
+        ex: &Experiment,
+        krate: Crate,
+        tc: Toolchain,
+        res: TestResult,
+    ) {
+        self.experiments
+            .entry(ex.name.to_string())
+            .or_insert_with(DummyData::default)
+            .results
+            .insert((krate, tc), res);
+    }
+}
+
+impl ReadResults for DummyDB {
+    fn load_all_shas(&self, ex: &Experiment) -> Result<HashMap<GitHubRepo, String>> {
+        Ok(self.get_data(ex)?.shas.clone())
+    }
+
+    fn load_log(
+        &self,
+        ex: &Experiment,
+        toolchain: &Toolchain,
+        krate: &Crate,
+    ) -> Result<Option<Vec<u8>>> {
+        Ok(self.get_data(ex)?
+            .logs
+            .get(&(krate.clone(), toolchain.clone()))
+            .cloned())
+    }
+
+    fn load_test_result(
+        &self,
+        ex: &Experiment,
+        toolchain: &Toolchain,
+        krate: &Crate,
+    ) -> Result<Option<TestResult>> {
+        Ok(self.get_data(ex)?
+            .results
+            .get(&(krate.clone(), toolchain.clone()))
+            .cloned())
+    }
+}

--- a/src/results/file.rs
+++ b/src/results/file.rs
@@ -3,6 +3,7 @@ use errors::*;
 use ex::{ex_dir, Experiment};
 use file;
 use log;
+use results::{ReadResults, WriteResults, DeleteResults, TestResult};
 use serde_json;
 use std::collections::HashMap;
 use std::fs::{self, File};
@@ -11,46 +12,6 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use toolchain::Toolchain;
 use util;
-
-pub trait ReadResults {
-    fn load_all_shas(&self, ex: &Experiment) -> Result<HashMap<GitHubRepo, String>>;
-    fn load_log(
-        &self,
-        ex: &Experiment,
-        toolchain: &Toolchain,
-        krate: &Crate,
-    ) -> Result<Option<Vec<u8>>>;
-    fn load_test_result(
-        &self,
-        ex: &Experiment,
-        toolchain: &Toolchain,
-        krate: &Crate,
-    ) -> Result<Option<TestResult>>;
-}
-
-pub trait WriteResults {
-    fn already_executed(
-        &self,
-        ex: &Experiment,
-        toolchain: &Toolchain,
-        krate: &Crate,
-    ) -> Result<Option<TestResult>>;
-    fn record_sha(&self, ex: &Experiment, repo: &GitHubRepo, sha: &str) -> Result<()>;
-    fn record_result<F>(
-        &self,
-        ex: &Experiment,
-        toolchain: &Toolchain,
-        krate: &Crate,
-        f: F,
-    ) -> Result<TestResult>
-    where
-        F: FnOnce() -> Result<TestResult>;
-}
-
-pub trait DeleteResults {
-    fn delete_all_results(&self, ex: &Experiment) -> Result<()>;
-    fn delete_result(&self, ex: &Experiment, toolchain: &Toolchain, krate: &Crate) -> Result<()>;
-}
 
 #[derive(Clone, Default)]
 pub struct FileDB {
@@ -199,10 +160,3 @@ impl DeleteResults for FileDB {
         Ok(())
     }
 }
-
-string_enum!(pub enum TestResult {
-    BuildFail => "build-fail",
-    TestFail => "test-fail",
-    TestSkipped => "test-skipped",
-    TestPass => "test-pass",
-});

--- a/src/results/file.rs
+++ b/src/results/file.rs
@@ -3,7 +3,7 @@ use errors::*;
 use ex::{ex_dir, Experiment};
 use file;
 use log;
-use results::{ReadResults, WriteResults, DeleteResults, TestResult};
+use results::{DeleteResults, ReadResults, TestResult, WriteResults};
 use serde_json;
 use std::collections::HashMap;
 use std::fs::{self, File};

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -1,0 +1,56 @@
+mod file;
+
+use crates::{Crate, GitHubRepo};
+use errors::*;
+use ex::Experiment;
+use std::collections::HashMap;
+use toolchain::Toolchain;
+
+pub use results::file::FileDB;
+
+pub trait ReadResults {
+    fn load_all_shas(&self, ex: &Experiment) -> Result<HashMap<GitHubRepo, String>>;
+    fn load_log(
+        &self,
+        ex: &Experiment,
+        toolchain: &Toolchain,
+        krate: &Crate,
+    ) -> Result<Option<Vec<u8>>>;
+    fn load_test_result(
+        &self,
+        ex: &Experiment,
+        toolchain: &Toolchain,
+        krate: &Crate,
+    ) -> Result<Option<TestResult>>;
+}
+
+pub trait WriteResults {
+    fn already_executed(
+        &self,
+        ex: &Experiment,
+        toolchain: &Toolchain,
+        krate: &Crate,
+    ) -> Result<Option<TestResult>>;
+    fn record_sha(&self, ex: &Experiment, repo: &GitHubRepo, sha: &str) -> Result<()>;
+    fn record_result<F>(
+        &self,
+        ex: &Experiment,
+        toolchain: &Toolchain,
+        krate: &Crate,
+        f: F,
+    ) -> Result<TestResult>
+    where
+        F: FnOnce() -> Result<TestResult>;
+}
+
+pub trait DeleteResults {
+    fn delete_all_results(&self, ex: &Experiment) -> Result<()>;
+    fn delete_result(&self, ex: &Experiment, toolchain: &Toolchain, krate: &Crate) -> Result<()>;
+}
+
+string_enum!(pub enum TestResult {
+    BuildFail => "build-fail",
+    TestFail => "test-fail",
+    TestSkipped => "test-skipped",
+    TestPass => "test-pass",
+});

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -1,12 +1,15 @@
+#[cfg(test)]
+mod dummy;
 mod file;
 
 use crates::{Crate, GitHubRepo};
 use errors::*;
 use ex::Experiment;
+#[cfg(test)]
+pub use results::dummy::DummyDB;
+pub use results::file::FileDB;
 use std::collections::HashMap;
 use toolchain::Toolchain;
-
-pub use results::file::FileDB;
 
 pub trait ReadResults {
     fn load_all_shas(&self, ex: &Experiment) -> Result<HashMap<GitHubRepo, String>>;

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -26,7 +26,7 @@ const RUST_CI_COMPONENTS: [(&str, &str); 3] = [
     ("cargo", "cargo-nightly-x86_64-unknown-linux-gnu.tar.xz"),
 ];
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Clone)]
 /// A toolchain name, either a rustup channel identifier,
 /// or a URL+branch+sha: `https://github.com/rust-lang/rust+master+sha`
 pub enum Toolchain {


### PR DESCRIPTION
This PR properly tests the reports generation, in response of #226:

* Unit tests for some of the basic functions: `crate_to_url`, `crate_to_name`, `crate_to_path_fragment`, `compare`
* Integration tests for the report generation: a whole report is generated from a dummy experiment, and its content is validated

In order to be able to properly test those things I had to add some dummy implementation of some traits, and I moved the results code around.

cc @aidanhs 