### PR TITLE
Fix git reset not executed inside the repository

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -23,6 +23,7 @@ pub fn shallow_clone_or_pull(url: &str, dir: &Path) -> Result<()> {
         info!("pulling existing url {} into {}", url, dir.display());
         RunCommand::new("git", &["fetch", "--all"]).cd(dir).run()?;
         RunCommand::new("git", &["reset", "--hard", "@{upstream}"])
+            .cd(dir)
             .run()
             .chain_err(|| format!("unable to pull {}", url))
     }


### PR DESCRIPTION
#216 forgot to change the directory when resetting the git branch, so the git command errored out every time it was called. This PR fixes that.