### PR TITLE
Correctly handle S3 tokens in craterbot

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,7 @@ error_chain! {
         ParseInt(::std::num::ParseIntError);
         Parse(::std::string::ParseError);
         RusotoTls(::rusoto_core::TlsError);
+        RusotoParseRegion(::rusoto_core::ParseRegionError);
         Rusqlite(::rusqlite::Error);
         R2D2(::r2d2::Error);
         Base64Decode(::base64::DecodeError);

--- a/tokens.example.toml
+++ b/tokens.example.toml
@@ -3,13 +3,22 @@ webhooks-secret = ""
 api-token = ""
 
 [reports-bucket]
-# This is configured by default to use the public minio playground
-# S3 can be changed by setting the region name (for example "us-east-1")
-region = ["custom", "https://play.minio.io:9000"]
 bucket = "crater-reports"
-public-url = "https://play.minio.io:9000"
+
+# Configuration for the minio playground
+# This requires no authentication (credentials are public) and it's great for
+# local testing, but it's purged every few days. You might have to recreate the
+# bucket manually if it was deleted.
+region = { type = "custom", url = "https://play.minio.io:9000" }
+public-url = "https://play.minio.io:9000/{bucket}"
 access-key = "Q3AM3UQ867SPQQA43P2F"
 secret-key = "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+
+# Configuration for production S3
+#region = { type = "s3", region = "us-west-1" }
+#public-url = "https://{bucket}.s3.amazonaws.com"
+#access-key = ""
+#secret-key = ""
 
 [agents]
 # "TOKEN" = "agent-name"


### PR DESCRIPTION
The reports upload in craterbot was only tested on the Minio playground instance, and it wasn't working correctly on S3. I managed to get a bucket to experiment on, and this PR adds proper support for it.

cc @aidanhs we want this merged before trying craterbot live.