### PR TITLE
Add support for team authentication in craterbot

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,9 @@
 [server]
 # The list of GitHub users allowed to interact with the GitHub bot
+# You can mix usernames and teams
 bot-acl = [
-    "pietroalbini",
-    "aidanhs",
+    "rust-lang/infra",
+    "rust-lang/release",
 ]
 
 [server.labels]

--- a/config.toml
+++ b/config.toml
@@ -2,8 +2,8 @@
 # The list of GitHub users allowed to interact with the GitHub bot
 # You can mix usernames and teams
 bot-acl = [
-    "rust-lang/infra",
-    "rust-lang/release",
+    "pietroalbini",
+    "aidanhs",
 ]
 
 [server.labels]

--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -98,3 +98,16 @@ without restarting the whole experiment, with the GitHub command
 
 * `name`: name of the experiment; required only if Crater [can't determine it
   automatically][auto-name]
+
+## Reload the list of GitHub team members
+
+Crater allows members of some teams (configured in `config.toml`) to interact
+with the GitHub bot, but the list of members is only loaded at startup. If a
+member joined or was removed from a team, you need to reload that list.
+
+It's possible to reload the list either restarting the Crater server or using
+the `reload-acl` command, which requires no arguments:
+
+```
+@craterbot reload-acl
+```

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use crates::Crate;
 use errors::*;
 use regex::Regex;
 use serde_regex;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 
@@ -30,7 +30,7 @@ fn default_false() -> bool {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServerConfig {
-    pub bot_acl: HashSet<String>,
+    pub bot_acl: Vec<String>,
     pub labels: ServerLabels,
 }
 
@@ -112,7 +112,7 @@ impl Default for Config {
             crates: HashMap::new(),
             github_repos: HashMap::new(),
             server: ServerConfig {
-                bot_acl: HashSet::new(),
+                bot_acl: Vec::new(),
                 labels: ServerLabels {
                     remove: Regex::new("^$").unwrap(),
                     experiment_queued: "".into(),

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,9 +1,13 @@
+use config::Config;
+use errors::*;
 use hyper::header::Authorization;
 use hyper::server::{Request, Response};
 use server::api_types::{ApiResponse, CraterToken};
+use server::github::GitHubApi;
 use server::http::{Context, Handler, ResponseExt, ResponseFuture};
 use server::Data;
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock};
 
 enum TokenType {
     Agent,
@@ -58,5 +62,71 @@ where
     AuthMiddleware {
         func,
         token_type: TokenType::Agent,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ACL {
+    cached_usernames: Arc<RwLock<HashSet<String>>>,
+    users: Vec<String>,
+    teams: Vec<(String, String)>,
+}
+
+impl ACL {
+    pub fn new(config: &Config, github: &GitHubApi) -> Result<Self> {
+        let mut users = Vec::new();
+        let mut teams = Vec::new();
+
+        for item in &config.server.bot_acl {
+            if let Some(middle) = item.find('/') {
+                let org = item[..middle].to_string();
+                let team = item[middle + 1..].to_string();
+                teams.push((org, team));
+            } else {
+                users.push(item.clone());
+            }
+        }
+
+        let acl = ACL {
+            cached_usernames: Arc::new(RwLock::new(HashSet::new())),
+            users,
+            teams,
+        };
+
+        acl.refresh_cache(github)?;
+        Ok(acl)
+    }
+
+    pub fn refresh_cache(&self, github: &GitHubApi) -> Result<()> {
+        // A new HashSet is created instead of clearing the old one
+        // This is done because if an error occurs the old cache is not flushed
+        let mut new_cache = HashSet::new();
+
+        for user in &self.users {
+            new_cache.insert(user.clone());
+        }
+
+        let mut orgs = HashMap::new();
+        for &(ref org, ref team) in &self.teams {
+            // Cache the list of teams in an org
+            if !orgs.contains_key(org) {
+                orgs.insert(org.clone(), github.list_teams(org)?);
+            }
+
+            let members = github.team_members(orgs[org][team])?;
+            for member in &members {
+                new_cache.insert(member.clone());
+            }
+        }
+
+        // Update the shared cache
+        let mut cache = self.cached_usernames.write().unwrap();
+        *cache = new_cache;
+
+        Ok(())
+    }
+
+    pub fn allowed(&self, username: &str) -> bool {
+        self.cached_usernames.read().unwrap().contains(username)
     }
 }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -137,7 +137,11 @@ impl ACL {
             orgs.insert(org.to_string(), github.list_teams(org)?);
         }
 
-        let members = github.team_members(orgs[org][team])?;
+        let members = github.team_members(
+            *orgs[org]
+                .get(team)
+                .ok_or_else(|| format!("team {}/{} doesn't exist", org, team))?,
+        )?;
         for member in &members {
             new_cache.insert(member.clone());
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -33,6 +33,7 @@ pub struct Data {
     pub experiments: Experiments,
     pub db: db::Database,
     pub reports_worker: reports::ReportsWorker,
+    pub acl: auth::ACL,
 }
 
 pub fn run(config: Config) -> Result<()> {
@@ -41,6 +42,7 @@ pub fn run(config: Config) -> Result<()> {
     let github = GitHubApi::new(&tokens);
     let agents = Agents::new(db.clone(), &tokens)?;
     let bot_username = github.username()?;
+    let acl = auth::ACL::new(&config, &github)?;
 
     info!("bot username: {}", bot_username);
 
@@ -53,6 +55,7 @@ pub fn run(config: Config) -> Result<()> {
         experiments: Experiments::new(db.clone()),
         db: db.clone(),
         reports_worker: reports::ReportsWorker::new(),
+        acl,
     };
 
     data.reports_worker.spawn(data.clone());

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -107,6 +107,8 @@ generate_parser!(pub enum Command {
         name: Option<String> = "name",
     })
 
+    "reload-acl" => ReloadACL(ReloadACLArgs {})
+
     _ => Edit(EditArgs {
         name: Option<String> = "name",
         start: Option<Toolchain> = "start",

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -147,6 +147,16 @@ pub fn abort(data: &Data, issue: &Issue, args: AbortArgs) -> Result<()> {
     Ok(())
 }
 
+pub fn reload_acl(data: &Data, issue: &Issue) -> Result<()> {
+    data.acl.refresh_cache(&data.github)?;
+
+    Message::new()
+        .line("hammer_and_wrench", "List of authorized users reloaded!")
+        .send(&issue.url, data)?;
+
+    Ok(())
+}
+
 fn get_name(db: &Database, issue: &Issue, name: Option<String>) -> Result<String> {
     if let Some(name) = name {
         store_experiment_name(db, issue, &name)?;

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -59,7 +59,7 @@ fn process_command(sender: &str, body: &str, issue: &Issue, data: &Data) -> Resu
             continue;
         }
 
-        if !data.config.server.bot_acl.contains(sender) {
+        if !data.acl.allowed(sender) {
             Message::new()
                 .line(
                     "lock",
@@ -98,6 +98,10 @@ fn process_command(sender: &str, body: &str, issue: &Issue, data: &Data) -> Resu
 
             Command::Abort(args) => {
                 commands::abort(data, issue, args)?;
+            }
+
+            Command::ReloadACL(_) => {
+                commands::reload_acl(data, issue)?;
             }
         }
 


### PR DESCRIPTION
This PR allows whole teams in the list of allowed craterbot users. The list of team members is fetched at startup, and a `reload-acl` GitHub command reloads the list without restarting the instance. For now release and infra are allowed.  