### PR TITLE
Escape crate log URLs in reports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ extern crate tokio_io;
 extern crate tokio_process;
 extern crate tokio_timer;
 extern crate toml;
+#[macro_use]
 extern crate url;
 extern crate walkdir;
 


### PR DESCRIPTION
S3 doesn't allow `+` unescaped in the URLs, and some crates have that char in their version. This PR escapes all crate names in log URLs.

Fixes #153 