### PR TITLE
Limit available RAM in Docker containers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,6 +21,11 @@ crates = ["lazy_static"]
 github-repos = ["brson/hello-rs"]
 
 
+[sandbox]
+# Maximum amount of RAM allowed during builds
+memory-limit = "2G"
+
+
 # These sections allows to customize how crater treats specific crates/repos
 #
 # The available options for each crate/repo are:

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,11 +52,18 @@ pub struct DemoCrates {
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+pub struct SandboxConfig {
+    pub memory_limit: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Config {
     pub demo_crates: DemoCrates,
     pub crates: HashMap<String, CrateConfig>,
     pub github_repos: HashMap<String, CrateConfig>,
     pub server: ServerConfig,
+    pub sandbox: SandboxConfig,
 }
 
 impl Config {
@@ -111,6 +118,9 @@ impl Default for Config {
             },
             crates: HashMap::new(),
             github_repos: HashMap::new(),
+            sandbox: SandboxConfig {
+                memory_limit: "2G".into(),
+            },
             server: ServerConfig {
                 bot_acl: HashSet::new(),
                 labels: ServerLabels {
@@ -141,6 +151,8 @@ mod tests {
             "[demo-crates]\n",
             "crates = []\n",
             "github-repos = []\n",
+            "[sandbox]\n",
+            "memory-limit = \"2G\"\n",
             "[crates]\n",
             "lazy_static = { skip = true }\n",
             "\n",

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use serde_regex;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
+use util::Size;
 
 static CONFIG_FILE: &'static str = "config.toml";
 
@@ -53,7 +54,7 @@ pub struct DemoCrates {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SandboxConfig {
-    pub memory_limit: String,
+    pub memory_limit: Size,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -119,7 +120,7 @@ impl Default for Config {
             crates: HashMap::new(),
             github_repos: HashMap::new(),
             sandbox: SandboxConfig {
-                memory_limit: "2G".into(),
+                memory_limit: Size::Gigabytes(2),
             },
             server: ServerConfig {
                 bot_acl: HashSet::new(),

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fmt::{self, Display, Formatter};
 use std::fs;
 use std::path::{Path, PathBuf};
-use util;
+use util::{self, Size};
 
 pub static IMAGE_NAME: &'static str = "crater";
 
@@ -50,7 +50,7 @@ pub struct ContainerBuilder<'a> {
     image: &'a str,
     mounts: Vec<MountConfig<'a>>,
     env: Vec<(&'static str, String)>,
-    memory_limit: Option<&'a str>,
+    memory_limit: Option<Size>,
 }
 
 impl<'a> ContainerBuilder<'a> {
@@ -77,7 +77,7 @@ impl<'a> ContainerBuilder<'a> {
         self
     }
 
-    pub fn memory_limit(mut self, limit: &'a str) -> Self {
+    pub fn memory_limit(mut self, limit: Size) -> Self {
         self.memory_limit = Some(limit);
         self
     }
@@ -98,7 +98,7 @@ impl<'a> ContainerBuilder<'a> {
 
         if let Some(limit) = self.memory_limit {
             args.push("-m".into());
-            args.push(limit.into());
+            args.push(limit.to_string());
         }
 
         args.push(self.image.into());

--- a/src/ex.rs
+++ b/src/ex.rs
@@ -362,13 +362,14 @@ pub fn capture_lockfile(
 
     with_work_crate(ex, toolchain, krate, |path| {
         with_frobbed_toml(ex, krate, path)?;
-        capture_lockfile_inner(ex, krate, path, toolchain)
+        capture_lockfile_inner(config, ex, krate, path, toolchain)
     }).chain_err(|| format!("failed to generate lockfile for {}", krate))?;
 
     Ok(())
 }
 
 fn capture_lockfile_inner(
+    config: &Config,
     ex: &Experiment,
     krate: &Crate,
     path: &Path,
@@ -381,7 +382,7 @@ fn capture_lockfile_inner(
         "-Zno-index-update",
     ];
     toolchain
-        .run_cargo(ex, path, args, CargoState::Unlocked, false, false)
+        .run_cargo(config, ex, path, args, CargoState::Unlocked, false, false)
         .chain_err(|| format!("unable to generate lockfile for {}", krate))?;
 
     let src_lockfile = &path.join("Cargo.lock");
@@ -458,7 +459,7 @@ pub fn fetch_crate_deps(
 
         let args = &["fetch", "--locked", "--manifest-path", "Cargo.toml"];
         toolchain
-            .run_cargo(ex, path, args, CargoState::Unlocked, false, true)
+            .run_cargo(config, ex, path, args, CargoState::Unlocked, false, true)
             .chain_err(|| format!("unable to fetch deps for {}", krate))?;
 
         Ok(())

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -113,7 +113,7 @@ impl Toolchain {
             .env("RUST_BACKTRACE", "full".to_string())
             .env("RUSTFLAGS", format!("--cap-lints={}", ex.cap_lints.to_str()))
             // Add some limits to the container
-            .memory_limit(&config.sandbox.memory_limit);
+            .memory_limit(config.sandbox.memory_limit);
 
         if enable_unstable_cargo_features {
             container = container.env(
@@ -310,7 +310,7 @@ fn user_id() -> ::libc::uid_t {
     unsafe { ::libc::geteuid() }
 }
 
-#[cfg(unix)]
+#[cfg(windows)]
 fn user_id() -> u32 {
     unimplemented!();
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -1,6 +1,7 @@
+use config::Config;
 use dirs::{CARGO_HOME, RUSTUP_HOME, TARGET_DIR};
 use dl;
-use docker;
+use docker::{ContainerBuilder, MountPerms, IMAGE_NAME};
 use errors::*;
 use ex::Experiment;
 use run::RunCommand;
@@ -72,6 +73,7 @@ impl Toolchain {
 
     pub fn run_cargo(
         &self,
+        config: &Config,
         ex: &Experiment,
         source_dir: &Path,
         args: &[&str],
@@ -89,25 +91,38 @@ impl Toolchain {
         full_args.extend_from_slice(args);
 
         info!("running: {}", full_args.join(" "));
-        let perm = match cargo_state {
-            CargoState::Locked => docker::Perm::ReadOnly,
-            CargoState::Unlocked => docker::Perm::ReadWrite,
-        };
 
         let enable_unstable_cargo_features = !toolchain_name.starts_with("nightly-")
             && (unstable_cargo || args.iter().any(|a| a.starts_with("-Z")));
 
-        let rust_env = docker::RustEnv {
-            args: &full_args,
-            work_dir: (source_dir.into(), perm),
-            cargo_home: (Path::new(&*CARGO_HOME).into(), perm),
-            rustup_home: (Path::new(&*RUSTUP_HOME).into(), docker::Perm::ReadOnly),
-            // This is configured as CARGO_TARGET_DIR by the docker container itself
-            target_dir: (ex_target_dir, docker::Perm::ReadWrite),
-            cap_lints: &ex.cap_lints,
-            enable_unstable_cargo_features,
+        let perm = match cargo_state {
+            CargoState::Locked => MountPerms::ReadOnly,
+            CargoState::Unlocked => MountPerms::ReadWrite,
         };
-        docker::run(&docker::rust_container(rust_env), quiet)
+
+        let mut container = ContainerBuilder::new(IMAGE_NAME)
+            // Setup all the mount points
+            .mount(source_dir.into(), "/source", perm)
+            .mount(ex_target_dir, "/target", MountPerms::ReadWrite)
+            .mount(Path::new(&*CARGO_HOME).into(), "/cargo-home", perm)
+            .mount(Path::new(&*RUSTUP_HOME).into(), "/rustup-home", MountPerms::ReadOnly)
+            // Add environment variables
+            .env("USER_ID", user_id().to_string())
+            .env("CMD", full_args.join(" "))
+            .env("CARGO_INCREMENTAL", "0".to_string())
+            .env("RUST_BACKTRACE", "full".to_string())
+            .env("RUSTFLAGS", format!("--cap-lints={}", ex.cap_lints.to_str()))
+            // Add some limits to the container
+            .memory_limit(&config.sandbox.memory_limit);
+
+        if enable_unstable_cargo_features {
+            container = container.env(
+                "__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS",
+                "nightly".to_string(),
+            );
+        }
+
+        container.run(quiet)
     }
 
     pub fn prep_offline_registry(&self) -> Result<()> {
@@ -288,4 +303,14 @@ fn init_toolchain_from_ci(alt: bool, sha: &str) -> Result<()> {
                 )
             })
     })
+}
+
+#[cfg(unix)]
+fn user_id() -> ::libc::uid_t {
+    unsafe { ::libc::geteuid() }
+}
+
+#[cfg(unix)]
+fn user_id() -> u32 {
+    unimplemented!();
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,14 @@
 use errors::*;
+use serde::{
+    de::{Deserialize, Deserializer, Error as DeError, Visitor},
+    ser::{Serialize, Serializer},
+};
 use std::any::Any;
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::result::Result as StdResult;
+use std::str::FromStr;
 use std::thread;
 use std::time::Duration;
 
@@ -193,5 +200,115 @@ pub fn from_hex(input: &str) -> Result<Vec<u8>> {
         bail!("invalid hex length");
     } else {
         Ok(result)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Size {
+    Bytes(usize),
+    Kilobytes(usize),
+    Megabytes(usize),
+    Gigabytes(usize),
+    Terabytes(usize),
+}
+
+impl fmt::Display for Size {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Size::Bytes(count) => write!(f, "{}", count),
+            Size::Kilobytes(count) => write!(f, "{}K", count),
+            Size::Megabytes(count) => write!(f, "{}M", count),
+            Size::Gigabytes(count) => write!(f, "{}G", count),
+            Size::Terabytes(count) => write!(f, "{}T", count),
+        }
+    }
+}
+
+impl FromStr for Size {
+    type Err = Error;
+
+    fn from_str(mut input: &str) -> Result<Size> {
+        let mut last = input.chars().last().ok_or("empty size")?;
+
+        // Eat a trailing 'b'
+        if last == 'b' || last == 'B' {
+            input = &input[..input.len() - 1];
+            last = input.chars().last().ok_or("empty size")?;
+        }
+
+        if last == 'K' || last == 'k' {
+            Ok(Size::Kilobytes(input[..input.len() - 1].parse()?))
+        } else if last == 'M' || last == 'm' {
+            Ok(Size::Megabytes(input[..input.len() - 1].parse()?))
+        } else if last == 'G' || last == 'g' {
+            Ok(Size::Gigabytes(input[..input.len() - 1].parse()?))
+        } else if last == 'T' || last == 't' {
+            Ok(Size::Terabytes(input[..input.len() - 1].parse()?))
+        } else {
+            Ok(Size::Bytes(input.parse()?))
+        }
+    }
+}
+
+struct SizeVisitor;
+
+impl<'de> Visitor<'de> for SizeVisitor {
+    type Value = Size;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("a size")
+    }
+
+    fn visit_str<E: DeError>(self, input: &str) -> StdResult<Size, E> {
+        Size::from_str(input).map_err(E::custom)
+    }
+}
+
+impl<'de> Deserialize<'de> for Size {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Size, D::Error> {
+        deserializer.deserialize_str(SizeVisitor)
+    }
+}
+
+impl Serialize for Size {
+    fn serialize<S: Serializer>(&self, serializer: S) -> StdResult<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Size;
+
+    #[test]
+    fn test_size() {
+        assert_eq!("1234".parse::<Size>().unwrap(), Size::Bytes(1234));
+        assert_eq!("1234B".parse::<Size>().unwrap(), Size::Bytes(1234));
+        assert_eq!("1234b".parse::<Size>().unwrap(), Size::Bytes(1234));
+        assert_eq!(Size::Bytes(1234).to_string(), "1234");
+
+        assert_eq!("1234K".parse::<Size>().unwrap(), Size::Kilobytes(1234));
+        assert_eq!("1234k".parse::<Size>().unwrap(), Size::Kilobytes(1234));
+        assert_eq!("1234KB".parse::<Size>().unwrap(), Size::Kilobytes(1234));
+        assert_eq!("1234kb".parse::<Size>().unwrap(), Size::Kilobytes(1234));
+        assert_eq!(Size::Kilobytes(1234).to_string(), "1234K");
+
+        assert_eq!("1234M".parse::<Size>().unwrap(), Size::Megabytes(1234));
+        assert_eq!("1234m".parse::<Size>().unwrap(), Size::Megabytes(1234));
+        assert_eq!("1234MB".parse::<Size>().unwrap(), Size::Megabytes(1234));
+        assert_eq!("1234mb".parse::<Size>().unwrap(), Size::Megabytes(1234));
+        assert_eq!(Size::Megabytes(1234).to_string(), "1234M");
+
+        assert_eq!("1234G".parse::<Size>().unwrap(), Size::Gigabytes(1234));
+        assert_eq!("1234g".parse::<Size>().unwrap(), Size::Gigabytes(1234));
+        assert_eq!("1234GB".parse::<Size>().unwrap(), Size::Gigabytes(1234));
+        assert_eq!("1234Gb".parse::<Size>().unwrap(), Size::Gigabytes(1234));
+        assert_eq!(Size::Gigabytes(1234).to_string(), "1234G");
+
+        assert_eq!("1234T".parse::<Size>().unwrap(), Size::Terabytes(1234));
+        assert_eq!("1234t".parse::<Size>().unwrap(), Size::Terabytes(1234));
+        assert_eq!("1234TB".parse::<Size>().unwrap(), Size::Terabytes(1234));
+        assert_eq!("1234Tb".parse::<Size>().unwrap(), Size::Terabytes(1234));
+        assert_eq!(Size::Terabytes(1234).to_string(), "1234T");
     }
 }


### PR DESCRIPTION
This PR limits the amount of available RAM to each Docker container to 2GB. I think this should be enough for most of the crates, but the value can easily be tweaked in the config file.

The PR also contains a refactoring of the `docker.rs` file.

Fixes #258 
cc @Mark-Simulacrum @aidanhs 