### PR TITLE
Add support for setting custom rustflags for a toolchain

### DIFF
--- a/assets/report.css
+++ b/assets/report.css
@@ -93,6 +93,25 @@ header div.toolchains div.toolchain.toolchain-start div {
     text-align: right;
 }
 
+header div.toolchains div.toolchain div.flags {
+    margin-top: 0.2em;
+    font-size: 0.9em;
+    color: #999;
+}
+
+header div.toolchains div.toolchain div.flags span {
+    display: inline-block;
+    margin-left: 0.5em;
+}
+
+header div.toolchains div.toolchain div.flags span:first-child {
+    margin-left: 0;
+}
+
+header div.toolchains div.toolchain div.flags code {
+    color: #eee;
+}
+
 header div.toolchains div.arrow {
     flex: 0;
     height: 0;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,5 +41,9 @@ error_chain! {
             description("invalid toolchain source name")
             display("invalid toolchain source name: {}", name)
         }
+        InvalidToolchainFlag(name: String) {
+            description("invalid toolchain flag")
+            display("invalid toolchain flag: {}", name)
+        }
     }
 }

--- a/src/server/experiments.rs
+++ b/src/server/experiments.rs
@@ -218,6 +218,7 @@ impl ExperimentData {
         }
 
         self.experiment.crates = new_crates;
+
         Ok(())
     }
 }

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -6,6 +6,12 @@
     {%- else -%}
         {{ tc.source|json_encode }}
     {%- endif -%}
+
+    <div class="flags">
+        {% if tc.rustflags %}
+            <span>rustflags: <code>{{ tc.rustflags }}</code></span>
+        {% endif %}
+    </div>
 {% endmacro %}
 
 {% macro render_time(date) %}


### PR DESCRIPTION
This PR adds full support for runs with custom toolchains, like NLL runs:

```
nightly-1970-01-01 nightly-1970-01-01+rustflags=-Zborrowck=mir
```

Fixes #255 
Fixes #257 

![screenshot from 2018-09-03 15-49-26](https://user-images.githubusercontent.com/2299951/44990324-f7a90200-af90-11e8-8579-2d69fb3959bf.png)