### PR TITLE
allow building on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio-timer = "0.1.1"
 toml = "0.4.6"
 url = "1.1"
 walkdir = "2"
+winapi = "0.3"
 regex = "0.2.10"
 ring = "0.12.1"
 rusqlite = { version = "0.13.0", features = ["chrono"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate handlebars;
 extern crate hyper;
 #[macro_use]
 extern crate lazy_static;
+#[cfg(not(windows))]
 extern crate libc;
 extern crate mime;
 extern crate petgraph;
@@ -55,6 +56,8 @@ extern crate toml;
 #[macro_use]
 extern crate url;
 extern crate walkdir;
+#[cfg(windows)]
+extern crate winapi;
 
 pub mod agent;
 #[macro_use]

--- a/src/run.rs
+++ b/src/run.rs
@@ -181,9 +181,12 @@ fn log_command(mut cmd: Command, capture: bool, quiet: bool) -> Result<ProcessOu
     #[cfg(windows)]
     fn kill_process(id: u32) {
         unsafe {
-            let handle = kernel32::OpenProcess(winapi::winnt::PROCESS_TERMINATE, 0, id);
-            kernel32::TerminateProcess(handle, 101);
-            if kernel32::CloseHandle(handle) == 0 {
+            use winapi::um::handleapi::CloseHandle;
+            use winapi::um::processthreadsapi::{OpenProcess, TerminateProcess};
+            use winapi::um::winnt::PROCESS_TERMINATE;
+            let handle = OpenProcess(PROCESS_TERMINATE, 0, id);
+            TerminateProcess(handle, 101);
+            if CloseHandle(handle) == 0 {
                 panic!("CloseHandle for process {} failed", id);
             }
         };


### PR DESCRIPTION
Cargo build did not work on windows. looks like it was broken in https://github.com/rust-lang-nursery/crater/pull/104 witch removed winapi as a dependency even tho it was used in the code.

I also added cross running cargo check to the lint run in ci so hopefully this will not regras so easily.