### PR TITLE
Use more explicit language for what crater tests against

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crater [![Build Status](https://travis-ci.org/rust-lang-nursery/crater.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/crater)
 
-Crater is a tool to run experiments across the whole Rust ecosystem. Its
+Crater is a tool to run experiments across a large number of crates on crates.io. Its
 primary purpose is to detect regressions in the Rust compiler, and it does this
 by building large number of crates, running their test suites and comparing the
 results between two versions of the Rust compiler.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crater [![Build Status](https://travis-ci.org/rust-lang-nursery/crater.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/crater)
 
-Crater is a tool to run experiments across a large number of crates on crates.io. Its
+Crater is a tool to run experiments across parts of the Rust ecosystem. Its
 primary purpose is to detect regressions in the Rust compiler, and it does this
 by building large number of crates, running their test suites and comparing the
 results between two versions of the Rust compiler.

--- a/docs/legacy-workflow.md
+++ b/docs/legacy-workflow.md
@@ -143,7 +143,7 @@ the sheet that does not have a status of 'Complete' or 'Failed'.
    - Update either the PR or the person requesting the beta run. Template is:
      > Hi X (crater requester), Y (PR reviewer)! Crater results are at: \<url>. 'Blacklisted' crates (spurious failures etc) can be found \[here\](https://github.com/rust-lang-nursery/crater/blob/master/config.toml). If you see any spurious failures not on the list, please make a PR against that file.
      >
-     > (interested observers: Crater is a tool for testing the impact of changes on a large portion of the crates.io ecosystem. You can find out more at the \[repo\](https://github.com/rust-lang-nursery/crater/) if you're curious)
+     > (interested observers: Crater is a tool for testing the impact of changes on parts of the Rust ecosystem. You can find out more at the \[repo\](https://github.com/rust-lang-nursery/crater/) if you're curious)
    - Give yourself a pat on the back! Good job!
    - Go to next run.
 

--- a/docs/legacy-workflow.md
+++ b/docs/legacy-workflow.md
@@ -143,7 +143,7 @@ the sheet that does not have a status of 'Complete' or 'Failed'.
    - Update either the PR or the person requesting the beta run. Template is:
      > Hi X (crater requester), Y (PR reviewer)! Crater results are at: \<url>. 'Blacklisted' crates (spurious failures etc) can be found \[here\](https://github.com/rust-lang-nursery/crater/blob/master/config.toml). If you see any spurious failures not on the list, please make a PR against that file.
      >
-     > (interested observers: Crater is a tool for testing the impact of changes on the crates.io ecosystem. You can find out more at the \[repo\](https://github.com/rust-lang-nursery/crater/) if you're curious)
+     > (interested observers: Crater is a tool for testing the impact of changes on a large portion of the crates.io ecosystem. You can find out more at the \[repo\](https://github.com/rust-lang-nursery/crater/) if you're curious)
    - Give yourself a pat on the back! Good job!
    - Go to next run.
 

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -51,7 +51,7 @@ impl Message {
         // Always add a note at the bottom explaining what this is
         self = self.note(
             "information_source",
-            "**Crater** is a tool to run experiments across a large number of crates on crates.io. \
+            "**Crater** is a tool to run experiments across parts of the Rust ecosystem. \
              [Learn more](https://github.com/rust-lang-nursery/crater)",
         );
 

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -51,7 +51,7 @@ impl Message {
         // Always add a note at the bottom explaining what this is
         self = self.note(
             "information_source",
-            "**Crater** is a tool to run experiments across the whole Rust ecosystem. \
+            "**Crater** is a tool to run experiments across a large number of crates on crates.io. \
              [Learn more](https://github.com/rust-lang-nursery/crater)",
         );
 


### PR DESCRIPTION
Having a bot comment on issues saying that this tests "the entire Rust
ecosystem" is misleading, since it only tests code which is published on
crates.io, and only a subset of those crates.

I've purposely chosen the more conservative language of "a large number
of crates" instead of "most crates" to avoid implying that we consider
windows only crates, crates which rely on nightly features, crates which
require system libraries, or other crates that we can't test for various
reasons to be a "minority"