### PR TITLE
Enable unstable cargo features during cargo fetch

### DIFF
--- a/src/ex.rs
+++ b/src/ex.rs
@@ -381,7 +381,7 @@ fn capture_lockfile_inner(
         "-Zno-index-update",
     ];
     toolchain
-        .run_cargo(ex, path, args, CargoState::Unlocked, false)
+        .run_cargo(ex, path, args, CargoState::Unlocked, false, false)
         .chain_err(|| format!("unable to generate lockfile for {}", krate))?;
 
     let src_lockfile = &path.join("Cargo.lock");
@@ -458,7 +458,7 @@ pub fn fetch_crate_deps(
 
         let args = &["fetch", "--locked", "--manifest-path", "Cargo.toml"];
         toolchain
-            .run_cargo(ex, path, args, CargoState::Unlocked, false)
+            .run_cargo(ex, path, args, CargoState::Unlocked, false, true)
             .chain_err(|| format!("unable to fetch deps for {}", krate))?;
 
         Ok(())

--- a/src/ex_run.rs
+++ b/src/ex_run.rs
@@ -240,6 +240,7 @@ fn build(ex: &Experiment, source_path: &Path, toolchain: &Toolchain, quiet: bool
         &["build", "--frozen"],
         CargoState::Locked,
         quiet,
+        false,
     )?;
     toolchain.run_cargo(
         ex,
@@ -247,6 +248,7 @@ fn build(ex: &Experiment, source_path: &Path, toolchain: &Toolchain, quiet: bool
         &["test", "--frozen", "--no-run"],
         CargoState::Locked,
         quiet,
+        false,
     )?;
     Ok(())
 }
@@ -258,6 +260,7 @@ fn test(ex: &Experiment, source_path: &Path, toolchain: &Toolchain, quiet: bool)
         &["test", "--frozen"],
         CargoState::Locked,
         quiet,
+        false,
     )
 }
 
@@ -308,6 +311,7 @@ pub fn test_check_only(
         &["check", "--frozen", "--all", "--all-targets"],
         CargoState::Locked,
         quiet,
+        false,
     );
 
     if r.is_ok() {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -77,6 +77,7 @@ impl Toolchain {
         args: &[&str],
         cargo_state: CargoState,
         quiet: bool,
+        unstable_cargo: bool,
     ) -> Result<()> {
         let toolchain_name = self.rustup_name();
         let ex_target_dir = self.target_dir(&ex.name);
@@ -93,8 +94,8 @@ impl Toolchain {
             CargoState::Unlocked => docker::Perm::ReadWrite,
         };
 
-        let enable_unstable_cargo_features =
-            !toolchain_name.starts_with("nightly-") && args.iter().any(|a| a.starts_with("-Z"));
+        let enable_unstable_cargo_features = !toolchain_name.starts_with("nightly-")
+            && (unstable_cargo || args.iter().any(|a| a.starts_with("-Z")));
 
         let rust_env = docker::RustEnv {
             args: &full_args,


### PR DESCRIPTION
Fixing #274 on the cargo side seems to be hard (https://github.com/rust-lang/cargo/issues/5704#issuecomment-404197503), so the easiest way is to just enable cargo unstable features during `cargo fetch`.

Fixes #274