### PR TITLE
Run `cargo check` on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+environment:
+  matrix:
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: stable
+
+matrix:
+  allow_failures:
+    - CHANNEL: nightly
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+install:
+  - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init.exe -y --default-toolchain %CHANNEL% --default-host %TARGET%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -V
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo check


### PR DESCRIPTION
This PR adds a basic Windows CI to Crater, to avoid we regress in platform support. `cargo build` is not run because SQLite is missing from image and I have near zero experience developing on Windows.

Fixes #275 