### PR TITLE
Toolchain refactorings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
  "minifier 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_sqlite 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2_sqlite 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ref_slice 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -242,7 +242,7 @@ dependencies = [
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_s3 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1171,11 +1171,11 @@ dependencies = [
 
 [[package]]
 name = "r2d2_sqlite"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "r2d2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2400,7 +2400,7 @@ dependencies = [
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum r2d2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f9078ca6a8a5568ed142083bb2f7dc9295b69d16f867ddcc9849e51b17d8db46"
-"checksum r2d2_sqlite 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "40a2a577eca774497be258ff0f9532f09ed5cec0f8e9cd06eb73c2b866636bbd"
+"checksum r2d2_sqlite 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d776a1bf225788bbe7f269c0ec574e467b1dfe50aee1541e88a193252cbc0d73"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
@@ -2421,7 +2421,7 @@ dependencies = [
 "checksum rusoto_core 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "407a38db12e644205491a55ecd93a858c90b817bea7b310f681b28a5a43c3a8e"
 "checksum rusoto_credential 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb6ad8cb6cb8e4538011777deebe08e26958ade7f18513914c194ac32ca92fe"
 "checksum rusoto_s3 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a0098ca4973610ccaf764e95feb626b450a55116cbdd41f7f7dd3e9ec7fb18f"
-"checksum rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9409d78a5a9646685688266e1833df8f08b71ffcae1b5db6c1bfb5970d8a80f"
+"checksum rusqlite 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c9d9118f1ce84d8d0b67f9779936432fb42bb620cef2122409d786892cce9a3c"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ walkdir = "2"
 winapi = "0.3"
 regex = "0.2.10"
 ring = "0.12.1"
-rusqlite = { version = "0.14.0", features = ["chrono", "bundled"] }
+rusqlite = { version = "0.14.0", features = ["chrono", "functions", "bundled"] }
 r2d2 = "0.8.2"
 r2d2_sqlite = "0.5.1"
 base64 = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,9 @@ walkdir = "2"
 winapi = "0.3"
 regex = "0.2.10"
 ring = "0.12.1"
-rusqlite = { version = "0.13.0", features = ["chrono", "bundled"] }
+rusqlite = { version = "0.14.0", features = ["chrono", "bundled"] }
 r2d2 = "0.8.2"
-r2d2_sqlite = "0.5.0"
+r2d2_sqlite = "0.5.1"
 base64 = "0.9.0"
 tera = "0.11.7"
 minifier = "0.0.11"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ use crater::report;
 use crater::results::FileDB;
 use crater::run_graph;
 use crater::server;
-use crater::toolchain::Toolchain;
+use crater::toolchain::{Toolchain, MAIN_TOOLCHAIN};
 use std::env;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -246,8 +246,7 @@ impl Crater {
             Crater::CreateLists => lists::create_all_lists(true)?,
             Crater::PrepareLocal { ref env } => {
                 let docker_env = &env.0;
-                let stable_tc = Toolchain::Dist("stable".into());
-                stable_tc.prepare()?;
+                MAIN_TOOLCHAIN.prepare()?;
                 docker::build_container(docker_env)?;
                 lists::create_all_lists(false)?;
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -263,7 +263,7 @@ impl Crater {
                 ex::define(
                     ex::ExOpts {
                         name: ex.0.clone(),
-                        toolchains: vec![tc1.clone(), tc2.clone()],
+                        toolchains: [tc1.clone(), tc2.clone()],
                         mode: *mode,
                         crates: *crates,
                         cap_lints: *cap_lints,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,5 +42,13 @@ error_chain! {
         ServerUnavailable {
             description("the server is not available at the moment")
         }
+
+        EmptyToolchainName {
+            description("empty toolchain name")
+        }
+        InvalidToolchainSourceName(name: String) {
+            description("invalid toolchain source name")
+            display("invalid toolchain source name: {}", name)
+        }
     }
 }

--- a/src/ex.rs
+++ b/src/ex.rs
@@ -158,6 +158,9 @@ pub fn define_(
         mode,
         cap_lints,
     };
+
+    ex.validate()?;
+
     fs::create_dir_all(&ex_dir(&ex.name))?;
     let json = serde_json::to_string(&ex)?;
     info!("writing ex config to {}", config_file(ex_name).display());
@@ -166,6 +169,14 @@ pub fn define_(
 }
 
 impl Experiment {
+    pub fn validate(&self) -> Result<()> {
+        if self.toolchains[0] == self.toolchains[1] {
+            bail!("reusing the same toolchain isn't supported");
+        }
+
+        Ok(())
+    }
+
     pub fn fetch_repo_crates(&self) -> Result<()> {
         for repo in self.crates.iter().filter_map(|krate| krate.github()) {
             if let Err(e) = git::shallow_clone_or_pull(&repo.url(), &repo.mirror_dir()) {
@@ -433,4 +444,36 @@ pub fn delete(ex_name: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ExCapLints, ExMode, Experiment};
+
+    #[test]
+    fn test_validate_experiment() {
+        // Correct experiment
+        assert!(
+            Experiment {
+                name: "foo".to_string(),
+                crates: vec![],
+                toolchains: vec!["stable".parse().unwrap(), "beta".parse().unwrap()],
+                mode: ExMode::BuildAndTest,
+                cap_lints: ExCapLints::Forbid,
+            }.validate()
+                .is_ok()
+        );
+
+        // Experiment with the same toolchain
+        assert!(
+            Experiment {
+                name: "foo".to_string(),
+                crates: vec![],
+                toolchains: vec!["stable".parse().unwrap(), "stable".parse().unwrap()],
+                mode: ExMode::BuildAndTest,
+                cap_lints: ExCapLints::Forbid,
+            }.validate()
+                .is_err()
+        );
+    }
 }

--- a/src/ex.rs
+++ b/src/ex.rs
@@ -56,14 +56,14 @@ fn froml_path(ex_name: &str, name: &str, vers: &str) -> PathBuf {
 pub struct Experiment {
     pub name: String,
     pub crates: Vec<Crate>,
-    pub toolchains: Vec<Toolchain>,
+    pub toolchains: [Toolchain; 2],
     pub mode: ExMode,
     pub cap_lints: ExCapLints,
 }
 
 pub struct ExOpts {
     pub name: String,
-    pub toolchains: Vec<Toolchain>,
+    pub toolchains: [Toolchain; 2],
     pub mode: ExMode,
     pub crates: ExCrateSelect,
     pub cap_lints: ExCapLints,
@@ -141,7 +141,7 @@ fn top_100() -> Result<Vec<Crate>> {
 
 pub fn define_(
     ex_name: &str,
-    toolchains: Vec<Toolchain>,
+    toolchains: [Toolchain; 2],
     crates: Vec<Crate>,
     mode: ExMode,
     cap_lints: ExCapLints,
@@ -449,6 +449,7 @@ pub fn delete(ex_name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{ExCapLints, ExMode, Experiment};
+    use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
     #[test]
     fn test_validate_experiment() {
@@ -457,7 +458,7 @@ mod tests {
             Experiment {
                 name: "foo".to_string(),
                 crates: vec![],
-                toolchains: vec!["stable".parse().unwrap(), "beta".parse().unwrap()],
+                toolchains: [MAIN_TOOLCHAIN.clone(), TEST_TOOLCHAIN.clone()],
                 mode: ExMode::BuildAndTest,
                 cap_lints: ExCapLints::Forbid,
             }.validate()
@@ -469,7 +470,7 @@ mod tests {
             Experiment {
                 name: "foo".to_string(),
                 crates: vec![],
-                toolchains: vec!["stable".parse().unwrap(), "stable".parse().unwrap()],
+                toolchains: [MAIN_TOOLCHAIN.clone(), MAIN_TOOLCHAIN.clone()],
                 mode: ExMode::BuildAndTest,
                 cap_lints: ExCapLints::Forbid,
             }.validate()

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -82,7 +82,11 @@ struct BuildTestResult {
 
 fn crate_to_path_fragment(toolchain: &Toolchain, krate: &Crate, encode: bool) -> PathBuf {
     let mut path = PathBuf::new();
-    path.push(toolchain.rustup_name());
+    if encode {
+        path.push(url_encode(&toolchain.to_string()));
+    } else {
+        path.push(toolchain.to_string());
+    }
 
     match *krate {
         Crate::Registry(ref details) => {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -120,8 +120,6 @@ pub fn generate_report<DB: ReadResults>(
     ex: &Experiment,
 ) -> Result<TestResults> {
     let shas = db.load_all_shas(ex)?;
-    assert_eq!(ex.toolchains.len(), 2);
-
     let res = ex
         .crates
         .clone()
@@ -565,7 +563,7 @@ mod tests {
         let ex = Experiment {
             name: "foo".to_string(),
             crates: vec![gh.clone()],
-            toolchains: vec![MAIN_TOOLCHAIN.clone(), TEST_TOOLCHAIN.clone()],
+            toolchains: [MAIN_TOOLCHAIN.clone(), TEST_TOOLCHAIN.clone()],
             mode: ExMode::BuildAndTest,
             cap_lints: ExCapLints::Forbid,
         };

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -342,7 +342,7 @@ mod tests {
     use ex::{ExCapLints, ExMode, Experiment};
     use results::{DummyDB, TestResult};
     use std::collections::HashMap;
-    use toolchain::Toolchain;
+    use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
     #[derive(Default)]
     pub struct DummyWriter {
@@ -394,7 +394,6 @@ mod tests {
 
     #[test]
     fn test_crate_to_path_fragment() {
-        let tc = Toolchain::Dist("stable".into());
         let reg = Crate::Registry(RegistryCrate {
             name: "lazy_static".into(),
             version: "1.0".into(),
@@ -409,19 +408,19 @@ mod tests {
         });
 
         assert_eq!(
-            crate_to_path_fragment(&tc, &reg, false),
+            crate_to_path_fragment(&MAIN_TOOLCHAIN, &reg, false),
             PathBuf::from("stable/reg/lazy_static-1.0")
         );
         assert_eq!(
-            crate_to_path_fragment(&tc, &gh, false),
+            crate_to_path_fragment(&MAIN_TOOLCHAIN, &gh, false),
             PathBuf::from("stable/gh/brson.hello-rs")
         );
         assert_eq!(
-            crate_to_path_fragment(&tc, &plus, false),
+            crate_to_path_fragment(&MAIN_TOOLCHAIN, &plus, false),
             PathBuf::from("stable/reg/foo-1.0+bar")
         );
         assert_eq!(
-            crate_to_path_fragment(&tc, &plus, true),
+            crate_to_path_fragment(&MAIN_TOOLCHAIN, &plus, true),
             PathBuf::from("stable/reg/foo-1.0%2Bbar")
         );
     }
@@ -559,23 +558,40 @@ mod tests {
         };
         let gh = Crate::GitHub(repo.clone());
 
-        let stable = Toolchain::Dist("stable".to_string());
-        let beta = Toolchain::Dist("beta".to_string());
-
         let ex = Experiment {
             name: "foo".to_string(),
             crates: vec![gh.clone()],
-            toolchains: vec![stable.clone(), beta.clone()],
+            toolchains: vec![MAIN_TOOLCHAIN.clone(), TEST_TOOLCHAIN.clone()],
             mode: ExMode::BuildAndTest,
             cap_lints: ExCapLints::Forbid,
         };
 
         let mut db = DummyDB::default();
         db.add_dummy_sha(&ex, repo.clone(), "f00".to_string());
-        db.add_dummy_result(&ex, gh.clone(), stable.clone(), TestResult::TestPass);
-        db.add_dummy_result(&ex, gh.clone(), beta.clone(), TestResult::BuildFail);
-        db.add_dummy_log(&ex, gh.clone(), stable.clone(), b"stable log".to_vec());
-        db.add_dummy_log(&ex, gh.clone(), beta.clone(), b"beta log".to_vec());
+        db.add_dummy_result(
+            &ex,
+            gh.clone(),
+            MAIN_TOOLCHAIN.clone(),
+            TestResult::TestPass,
+        );
+        db.add_dummy_result(
+            &ex,
+            gh.clone(),
+            TEST_TOOLCHAIN.clone(),
+            TestResult::BuildFail,
+        );
+        db.add_dummy_log(
+            &ex,
+            gh.clone(),
+            MAIN_TOOLCHAIN.clone(),
+            b"stable log".to_vec(),
+        );
+        db.add_dummy_log(
+            &ex,
+            gh.clone(),
+            TEST_TOOLCHAIN.clone(),
+            b"beta log".to_vec(),
+        );
 
         let writer = DummyWriter::default();
         gen(&db, &ex, &writer, &config).unwrap();

--- a/src/results/file.rs
+++ b/src/results/file.rs
@@ -31,7 +31,7 @@ impl FileDB {
 
         ex_dir(&ex.name)
             .join("res")
-            .join(toolchain.rustup_name())
+            .join(toolchain.to_string())
             .join(crate_path)
     }
 

--- a/src/server/agents.rs
+++ b/src/server/agents.rs
@@ -151,7 +151,7 @@ mod tests {
     use server::db::Database;
     use server::experiments::Experiments;
     use server::tokens::Tokens;
-    use toolchain::Toolchain;
+    use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
     #[test]
     fn test_agents_synchronize() {
@@ -231,8 +231,8 @@ mod tests {
         experiments
             .create(
                 "test".into(),
-                &Toolchain::Dist("stable".into()),
-                &Toolchain::Dist("beta".into()),
+                &MAIN_TOOLCHAIN,
+                &TEST_TOOLCHAIN,
                 ExMode::BuildAndTest,
                 ExCrateSelect::Demo,
                 ExCapLints::Forbid,

--- a/src/server/db/migrations.rs
+++ b/src/server/db/migrations.rs
@@ -2,108 +2,124 @@ use errors::*;
 use rusqlite::Connection;
 use std::collections::HashSet;
 
-fn migrations() -> Vec<(&'static str, &'static str)> {
+enum MigrationKind {
+    SQL(&'static str),
+}
+
+fn migrations() -> Vec<(&'static str, MigrationKind)> {
     let mut migrations = Vec::new();
 
     migrations.push((
         "initial",
-        "
-        CREATE TABLE experiments (
-            name TEXT PRIMARY KEY,
-            mode TEXT NOT NULL,
-            cap_lints TEXT NOT NULL,
+        MigrationKind::SQL(
+            "
+            CREATE TABLE experiments (
+                name TEXT PRIMARY KEY,
+                mode TEXT NOT NULL,
+                cap_lints TEXT NOT NULL,
 
-            toolchain_start TEXT NOT NULL,
-            toolchain_end TEXT NOT NULL,
+                toolchain_start TEXT NOT NULL,
+                toolchain_end TEXT NOT NULL,
 
-            priority INTEGER NOT NULL,
-            created_at DATETIME NOT NULL,
-            status TEXT NOT NULL,
-            github_issue TEXT,
-            github_issue_url TEXT,
-            github_issue_number INTEGER,
-            assigned_to TEXT,
+                priority INTEGER NOT NULL,
+                created_at DATETIME NOT NULL,
+                status TEXT NOT NULL,
+                github_issue TEXT,
+                github_issue_url TEXT,
+                github_issue_number INTEGER,
+                assigned_to TEXT,
 
-            FOREIGN KEY (assigned_to) REFERENCES agents(name) ON DELETE SET NULL
-        );
+                FOREIGN KEY (assigned_to) REFERENCES agents(name) ON DELETE SET NULL
+            );
 
-        CREATE TABLE experiment_crates (
-            experiment TEXT NOT NULL,
-            crate TEXT NOT NULL,
+            CREATE TABLE experiment_crates (
+                experiment TEXT NOT NULL,
+                crate TEXT NOT NULL,
 
-            FOREIGN KEY (experiment) REFERENCES experiments(name) ON DELETE CASCADE
-        );
+                FOREIGN KEY (experiment) REFERENCES experiments(name) ON DELETE CASCADE
+            );
 
-        CREATE TABLE results (
-            experiment TEXT NOT NULL,
-            crate TEXT NOT NULL,
-            toolchain TEXT NOT NULL,
-            result TEXT NOT NULL,
-            log BLOB NOT NULL,
+            CREATE TABLE results (
+                experiment TEXT NOT NULL,
+                crate TEXT NOT NULL,
+                toolchain TEXT NOT NULL,
+                result TEXT NOT NULL,
+                log BLOB NOT NULL,
 
-            PRIMARY KEY (experiment, crate, toolchain) ON CONFLICT REPLACE,
-            FOREIGN KEY (experiment) REFERENCES experiments(name) ON DELETE CASCADE
-        );
+                PRIMARY KEY (experiment, crate, toolchain) ON CONFLICT REPLACE,
+                FOREIGN KEY (experiment) REFERENCES experiments(name) ON DELETE CASCADE
+            );
 
-        CREATE TABLE shas (
-            experiment TEXT NOT NULL,
-            org TEXT NOT NULL,
-            name TEXT NOT NULL,
-            sha TEXT NOT NULL,
+            CREATE TABLE shas (
+                experiment TEXT NOT NULL,
+                org TEXT NOT NULL,
+                name TEXT NOT NULL,
+                sha TEXT NOT NULL,
 
-            FOREIGN KEY (experiment) REFERENCES experiments(name) ON DELETE CASCADE
-        );
+                FOREIGN KEY (experiment) REFERENCES experiments(name) ON DELETE CASCADE
+            );
 
-        CREATE TABLE agents (
-            name TEXT PRIMARY KEY,
-            last_heartbeat DATETIME
-        );
+            CREATE TABLE agents (
+                name TEXT PRIMARY KEY,
+                last_heartbeat DATETIME
+            );
 
-        CREATE TABLE saved_names (
-            issue INTEGER PRIMARY KEY ON CONFLICT REPLACE,
-            experiment TEXT NOT NULL
-        );
-        ",
+            CREATE TABLE saved_names (
+                issue INTEGER PRIMARY KEY ON CONFLICT REPLACE,
+                experiment TEXT NOT NULL
+            );
+            ",
+        ),
     ));
 
     migrations.push((
         "store_agents_revision",
-        "
-        ALTER TABLE agents ADD COLUMN git_revision TEXT;
-        ",
+        MigrationKind::SQL(
+            "
+            ALTER TABLE agents ADD COLUMN git_revision TEXT;
+            ",
+        ),
     ));
 
     migrations.push((
         "store_skipped_crates",
-        "
-        ALTER TABLE experiment_crates ADD COLUMN skipped INTEGER NOT NULL DEFAULT 0;
-        ",
+        MigrationKind::SQL(
+            "
+            ALTER TABLE experiment_crates ADD COLUMN skipped INTEGER NOT NULL DEFAULT 0;
+            ",
+        ),
     ));
 
     migrations.push((
         "add_ui_progress_percent_indexes",
-        "
-        CREATE INDEX experiment_crates__experiment_skipped
-        ON experiment_crates (experiment, skipped);
+        MigrationKind::SQL(
+            "
+            CREATE INDEX experiment_crates__experiment_skipped
+            ON experiment_crates (experiment, skipped);
 
-        CREATE INDEX results__experiment
-        ON results (experiment);
-        ",
+            CREATE INDEX results__experiment
+            ON results (experiment);
+            ",
+        ),
     ));
 
     migrations.push((
         "add_more_experiment_dates",
-        "
-        ALTER TABLE experiments ADD COLUMN started_at DATETIME;
-        ALTER TABLE experiments ADD COLUMN completed_at DATETIME;
-        ",
+        MigrationKind::SQL(
+            "
+            ALTER TABLE experiments ADD COLUMN started_at DATETIME;
+            ALTER TABLE experiments ADD COLUMN completed_at DATETIME;
+            ",
+        ),
     ));
 
     migrations.push((
         "store_report_url",
-        "
-        ALTER TABLE experiments ADD COLUMN report_url TEXT;
-        ",
+        MigrationKind::SQL(
+            "
+            ALTER TABLE experiments ADD COLUMN report_url TEXT;
+            ",
+        ),
     ));
 
     migrations
@@ -127,11 +143,13 @@ pub fn execute(db: &mut Connection) -> Result<()> {
         result
     };
 
-    for &(name, sql) in &migrations() {
+    for &(name, ref migration) in &migrations() {
         if !executed_migrations.contains(&name.to_string()) {
             let t = db.transaction()?;
-            t.execute_batch(sql)
-                .chain_err(|| format!("error running migration: {}", name))?;
+            match migration {
+                MigrationKind::SQL(sql) => t.execute_batch(sql),
+            }.chain_err(|| format!("error running migration: {}", name))?;
+
             t.execute("INSERT INTO migrations (name) VALUES (?1)", &[&name])?;
             t.commit()?;
 

--- a/src/server/experiments.rs
+++ b/src/server/experiments.rs
@@ -138,7 +138,7 @@ impl ExperimentData {
         db.execute(
             "UPDATE experiments SET toolchain_start = ?1 WHERE name = ?2;",
             &[
-                &serde_json::to_string(&self.experiment.toolchains[0])?,
+                &self.experiment.toolchains[0].to_string(),
                 &self.experiment.name.as_str(),
             ],
         )?;
@@ -152,7 +152,7 @@ impl ExperimentData {
         db.execute(
             "UPDATE experiments SET toolchain_end = ?1 WHERE name = ?2;",
             &[
-                &serde_json::to_string(&self.experiment.toolchains[1])?,
+                &self.experiment.toolchains[1].to_string(),
                 &self.experiment.name.as_str(),
             ],
         )?;
@@ -281,10 +281,7 @@ impl ExperimentDBRecord {
             experiment: Experiment {
                 name: self.name,
                 crates,
-                toolchains: vec![
-                    serde_json::from_str(&self.toolchain_start)?,
-                    serde_json::from_str(&self.toolchain_end)?,
-                ],
+                toolchains: vec![self.toolchain_start.parse()?, self.toolchain_end.parse()?],
                 cap_lints: self.cap_lints.parse()?,
                 mode: self.mode.parse()?,
             },
@@ -365,8 +362,8 @@ impl Experiments {
                     &name,
                     &mode.to_str(),
                     &cap_lints.to_str(),
-                    &serde_json::to_string(&toolchain_start)?,
-                    &serde_json::to_string(&toolchain_end)?,
+                    &toolchain_start.to_string(),
+                    &toolchain_end.to_string(),
                     &priority,
                     &Utc::now(),
                     &"queued",

--- a/src/server/experiments.rs
+++ b/src/server/experiments.rs
@@ -471,7 +471,7 @@ mod tests {
     use server::agents::Agents;
     use server::db::Database;
     use server::tokens::Tokens;
-    use toolchain::Toolchain;
+    use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
     #[test]
     fn test_experiment_creation() {
@@ -485,8 +485,8 @@ mod tests {
         experiments
             .create(
                 "test".into(),
-                &Toolchain::Dist("stable".into()),
-                &Toolchain::Dist("beta".into()),
+                &MAIN_TOOLCHAIN,
+                &TEST_TOOLCHAIN,
                 ExMode::BuildAndTest,
                 ExCrateSelect::Demo,
                 ExCapLints::Forbid,
@@ -503,10 +503,7 @@ mod tests {
         assert_eq!(ex.experiment.name.as_str(), "test");
         assert_eq!(
             ex.experiment.toolchains,
-            vec![
-                Toolchain::Dist("stable".into()),
-                Toolchain::Dist("beta".into()),
-            ]
+            vec![MAIN_TOOLCHAIN.clone(), TEST_TOOLCHAIN.clone()]
         );
         assert_eq!(ex.experiment.mode, ExMode::BuildAndTest);
         assert_eq!(ex.experiment.crates, ::ex::demo_list(&config).unwrap());
@@ -552,8 +549,8 @@ mod tests {
         experiments
             .create(
                 "test".into(),
-                &Toolchain::Dist("stable".into()),
-                &Toolchain::Dist("beta".into()),
+                &MAIN_TOOLCHAIN,
+                &TEST_TOOLCHAIN,
                 ExMode::BuildAndTest,
                 ExCrateSelect::Demo,
                 ExCapLints::Forbid,
@@ -567,8 +564,8 @@ mod tests {
         experiments
             .create(
                 "important".into(),
-                &Toolchain::Dist("stable".into()),
-                &Toolchain::Dist("beta".into()),
+                &MAIN_TOOLCHAIN,
+                &TEST_TOOLCHAIN,
                 ExMode::BuildAndTest,
                 ExCrateSelect::Demo,
                 ExCapLints::Forbid,

--- a/src/server/experiments.rs
+++ b/src/server/experiments.rs
@@ -281,7 +281,7 @@ impl ExperimentDBRecord {
             experiment: Experiment {
                 name: self.name,
                 crates,
-                toolchains: vec![self.toolchain_start.parse()?, self.toolchain_end.parse()?],
+                toolchains: [self.toolchain_start.parse()?, self.toolchain_end.parse()?],
                 cap_lints: self.cap_lints.parse()?,
                 mode: self.mode.parse()?,
             },
@@ -348,7 +348,7 @@ impl Experiments {
             Experiment {
                 name: name.to_string(),
                 crates: crates.clone(),
-                toolchains: vec![toolchain_start.clone(), toolchain_end.clone()],
+                toolchains: [toolchain_start.clone(), toolchain_end.clone()],
                 mode,
                 cap_lints,
             }.validate()?;
@@ -513,7 +513,7 @@ mod tests {
         assert_eq!(ex.experiment.name.as_str(), "test");
         assert_eq!(
             ex.experiment.toolchains,
-            vec![MAIN_TOOLCHAIN.clone(), TEST_TOOLCHAIN.clone()]
+            [MAIN_TOOLCHAIN.clone(), TEST_TOOLCHAIN.clone()]
         );
         assert_eq!(ex.experiment.mode, ExMode::BuildAndTest);
         assert_eq!(ex.experiment.crates, ::ex::demo_list(&config).unwrap());

--- a/src/server/results.rs
+++ b/src/server/results.rs
@@ -139,7 +139,7 @@ mod tests {
     use results::{ReadResults, TestResult};
     use server::db::Database;
     use server::experiments::Experiments;
-    use toolchain::Toolchain;
+    use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
     #[test]
     fn test_results_db() {
@@ -151,8 +151,8 @@ mod tests {
         experiments
             .create(
                 "test",
-                &Toolchain::Dist("stable".into()),
-                &Toolchain::Dist("beta".into()),
+                &MAIN_TOOLCHAIN,
+                &TEST_TOOLCHAIN,
                 ExMode::BuildAndTest,
                 ExCrateSelect::Demo,
                 ExCapLints::Forbid,
@@ -169,7 +169,6 @@ mod tests {
             name: "lazy_static".into(),
             version: "1".into(),
         });
-        let toolchain = Toolchain::Dist("stable".into());
 
         // Store a result and some SHAs
         results
@@ -178,7 +177,7 @@ mod tests {
                 &ProgressData {
                     results: vec![TaskResult {
                         krate: krate.clone(),
-                        toolchain: toolchain.clone(),
+                        toolchain: MAIN_TOOLCHAIN.clone(),
                         result: TestResult::TestPass,
                         log: base64::encode("foo"),
                     }],
@@ -203,11 +202,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            results.load_log(&ex, &toolchain, &krate).unwrap(),
+            results.load_log(&ex, &MAIN_TOOLCHAIN, &krate).unwrap(),
             Some("foo".as_bytes().to_vec())
         );
         assert_eq!(
-            results.load_test_result(&ex, &toolchain, &krate).unwrap(),
+            results
+                .load_test_result(&ex, &MAIN_TOOLCHAIN, &krate)
+                .unwrap(),
             Some(TestResult::TestPass)
         );
     }

--- a/src/server/results.rs
+++ b/src/server/results.rs
@@ -41,7 +41,7 @@ impl<'a> ResultsDB<'a> {
                     &[
                         &ex.name,
                         &serde_json::to_string(&result.krate)?,
-                        &serde_json::to_string(&result.toolchain)?,
+                        &result.toolchain.to_string(),
                         &result.result.to_str(),
                         &base64::decode(&result.log).chain_err(|| "invalid base64 log provided")?,
                     ],
@@ -93,7 +93,7 @@ impl<'a> ReadResults for ResultsDB<'a> {
              LIMIT 1;",
             &[
                 &ex.name,
-                &serde_json::to_string(toolchain)?,
+                &toolchain.to_string(),
                 &serde_json::to_string(krate)?,
             ],
             |row| row.get("log"),
@@ -114,7 +114,7 @@ impl<'a> ReadResults for ResultsDB<'a> {
                  LIMIT 1;",
                 &[
                     &ex.name,
-                    &serde_json::to_string(toolchain)?,
+                    &toolchain.to_string(),
                     &serde_json::to_string(krate)?,
                 ],
                 |row| row.get("result"),

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -6,7 +6,7 @@ use ex_run;
 use git;
 use results::{TestResult, WriteResults};
 use std::fmt;
-use toolchain::Toolchain;
+use toolchain::{Toolchain, MAIN_TOOLCHAIN};
 use util;
 
 pub enum TaskStep {
@@ -119,8 +119,6 @@ impl Task {
         ex: &Experiment,
         db: &DB,
     ) -> Result<()> {
-        let stable = Toolchain::Dist("stable".into());
-
         // Fetch repository data if it's a git repo
         if let Some(repo) = self.krate.github() {
             if let Err(e) = git::shallow_clone_or_pull(&repo.url(), &repo.mirror_dir()) {
@@ -132,8 +130,8 @@ impl Task {
 
         crates::prepare_crate(&self.krate)?;
         ex::frob_toml(ex, &self.krate)?;
-        ex::capture_lockfile(config, ex, &self.krate, &stable)?;
-        ex::fetch_crate_deps(config, ex, &self.krate, &stable)?;
+        ex::capture_lockfile(config, ex, &self.krate, &MAIN_TOOLCHAIN)?;
+        ex::fetch_crate_deps(config, ex, &self.krate, &MAIN_TOOLCHAIN)?;
 
         Ok(())
     }

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,16 +1,10 @@
 {% macro toolchain_name(tc) %}
-    {%- if tc.Dist -%}
-        {{ tc.Dist }}
-    {%- elif tc.TryBuild -%}
-        <a href="https://github.com/rust-lang/rust/commit/{{ tc.TryBuild.sha }}">
-            try#{{ tc.TryBuild.sha }}
-        </a>
-    {%- elif tc.Master -%}
-        <a href="https://github.com/rust-lang/rust/commit/{{ tc.Master.sha }}">
-            master#{{ tc.Master.sha }}
-        </a>
+    {%- if tc.source.type == "dist" %}
+        {{ tc.source.name }}
+    {%- elif tc.source.type == "ci" %}
+        <a href="https://github.com/rust-lang/rust/commit/{{ tc.source.sha }}">{{ tc.source.sha }}</a>
     {%- else -%}
-        {{ tc|json_encode }}
+        {{ tc.source|json_encode }}
     {%- endif -%}
 {% endmacro %}
 


### PR DESCRIPTION
This PR extracts the refactorings out of #262 to merge them sooner.

* Encapsulated the `Toolchain` enum into a struct (to allow new fields to be added in the future)
* Prevent running an experiment with the exact same toolchains
* Store toolchains as strings instead of JSON in the database (this allows future enum changes)
* Use fixed-length array for experiment toolchains instead of a vec