### PR TITLE
Disable timeout while preparing the docker image

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -16,7 +16,8 @@ pub fn build_container(docker_env: &str) -> Result<()> {
     RunCommand::new(
         "docker",
         &["build", "-f", &dockerfile, "-t", IMAGE_NAME, "docker"],
-    ).run()
+    ).enable_timeout(false)
+        .run()
 }
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
`crater prepare-local` always fails with the 15 minutes timeout. This PR disables the timeout to avoid problems.

Fixes #71 