### PR TITLE
Avoid including yanked crates in the lists

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ extern crate serde_regex;
     slog_log,
     slog_error,
     slog_warn,
-    slog_debug,
     slog_record,
     slog_record_static,
     slog_b,


### PR DESCRIPTION
At the moment, crates with every version yanked are included in the lists, even if we can't test them. This PR explicitly excludes them.