### PR TITLE
Handle HTTP 413 errors in the agents

### DIFF
--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -26,10 +26,16 @@ impl ResponseExt for ::reqwest::Response {
             | StatusCode::GatewayTimeout => {
                 return Err(ErrorKind::ServerUnavailable.into());
             }
+            StatusCode::PayloadTooLarge => bail!("payload to agent (misconfigured server?)"),
             _ => {}
         }
 
-        let result: ApiResponse<T> = self.json().chain_err(|| "failed to parse API response")?;
+        let result: ApiResponse<T> = self.json().chain_err(|| {
+            format!(
+                "failed to parse API response (status code {})",
+                self.status()
+            )
+        })?;
         match result {
             ApiResponse::Success { result } => Ok(result),
             ApiResponse::InternalError { error } => bail!("internal server error: {}", error),


### PR DESCRIPTION
Those are caused by a misconfigured nginx, which rejects requests with a payload larger than 1MB by default.