### PR TITLE
Unblacklist livesplit-core

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1549,7 +1549,6 @@ liquidfun = { skip = true } #automatic
 liste = { skip = true } #automatic
 lit = { skip-tests = true } #automatic
 live2d = { broken = true } # dependency yanked
-livesplit-core = { skip = true } #automatic
 llang = { skip = true } #automatic
 lldb = { skip = true } #automatic
 lldb-sys = { skip = true } #automatic


### PR DESCRIPTION
I published a new version. The old one had bench keys in the Cargo.toml which broke building the published version on crates.io as the benches were not published.