### PR TITLE
Issue 329

### DIFF
--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -16,7 +16,7 @@ pub fn ping(data: &Data, issue: &Issue) -> Result<()> {
 
 pub fn run(host: &str, data: &Data, issue: &Issue, args: RunArgs) -> Result<()> {
     let name = get_name(&data.db, issue, args.name)?;
-
+    
     ::actions::CreateExperiment {
         name: name.clone(),
         toolchains: [
@@ -37,14 +37,14 @@ pub fn run(host: &str, data: &Data, issue: &Issue, args: RunArgs) -> Result<()> 
     Message::new()
         .line(
             "ok_hand",
-            format!("Experiment **`[{}]({})`** created and queued.", name, host),
+            format!("Experiment [**`{}`**](http://{}/ex/{0}) created and queued.", name, host),
         ).set_label(Label::ExperimentQueued)
         .send(&issue.url, data)?;
 
     Ok(())
 }
 
-pub fn edit(host: &str, data: &Data, issue: &Issue, args: EditArgs) -> Result<()> {
+pub fn edit(data: &Data, issue: &Issue, args: EditArgs) -> Result<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
     let changed = ::actions::EditExperiment {
@@ -60,7 +60,7 @@ pub fn edit(host: &str, data: &Data, issue: &Issue, args: EditArgs) -> Result<()
         Message::new()
             .line(
                 "memo",
-                format!("Configuration of the **`[{}]({})`** experiment changed.", name, host),
+                format!("Configuration of the **`{}`** experiment changed.", name),
             ).send(&issue.url, data)?;
     } else {
         Message::new()
@@ -71,14 +71,14 @@ pub fn edit(host: &str, data: &Data, issue: &Issue, args: EditArgs) -> Result<()
     Ok(())
 }
 
-pub fn retry_report(host: &str, data: &Data, issue: &Issue, args: RetryReportArgs) -> Result<()> {
+pub fn retry_report(data: &Data, issue: &Issue, args: RetryReportArgs) -> Result<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
     if let Some(mut experiment) = Experiment::get(&data.db, &name)? {
         if experiment.status != Status::ReportFailed {
             bail!(
-                "generation of the report of the **`[{}]({})`** experiment didn't fail!",
-                name, host
+                "generation of the report of the **`{}`** experiment didn't fail!",
+                name
             );
         }
 
@@ -88,7 +88,7 @@ pub fn retry_report(host: &str, data: &Data, issue: &Issue, args: RetryReportArg
         Message::new()
             .line(
                 "hammer_and_wrench",
-                format!("Generation of the report for **`[{}]({})`** queued again.", name, host),
+                format!("Generation of the report for **`{}`** queued again.", name),
             ).set_label(Label::ExperimentQueued)
             .send(&issue.url, data)?;
 

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -16,7 +16,7 @@ pub fn ping(data: &Data, issue: &Issue) -> Result<()> {
 
 pub fn run(host: &str, data: &Data, issue: &Issue, args: RunArgs) -> Result<()> {
     let name = get_name(&data.db, issue, args.name)?;
-    
+
     ::actions::CreateExperiment {
         name: name.clone(),
         toolchains: [
@@ -37,7 +37,10 @@ pub fn run(host: &str, data: &Data, issue: &Issue, args: RunArgs) -> Result<()> 
     Message::new()
         .line(
             "ok_hand",
-            format!("Experiment [**`{}`**](http://{}/ex/{0}) created and queued.", name, host),
+            format!(
+                "Experiment [**`{}`**](https://{}/ex/{0}) created and queued.",
+                name, host
+            ),
         ).set_label(Label::ExperimentQueued)
         .send(&issue.url, data)?;
 

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -38,8 +38,13 @@ pub fn run(host: &str, data: &Data, issue: &Issue, args: RunArgs) -> Result<()> 
         .line(
             "ok_hand",
             format!(
-                "Experiment [**`{}`**](https://{}/ex/{0}) created and queued.",
-                name, host
+                "Experiment **`{}`** created and queued.", name
+            ),
+        )
+        .line(
+            "mag",
+            format!(
+                "You can check out [the queue](https://{}) and [this experiment's details](https://{0}/ex/{1}).", host, name
             ),
         ).set_label(Label::ExperimentQueued)
         .send(&issue.url, data)?;

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -14,7 +14,7 @@ pub fn ping(data: &Data, issue: &Issue) -> Result<()> {
     Ok(())
 }
 
-pub fn run(data: &Data, issue: &Issue, args: RunArgs) -> Result<()> {
+pub fn run(host: &str, data: &Data, issue: &Issue, args: RunArgs) -> Result<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
     ::actions::CreateExperiment {
@@ -37,14 +37,14 @@ pub fn run(data: &Data, issue: &Issue, args: RunArgs) -> Result<()> {
     Message::new()
         .line(
             "ok_hand",
-            format!("Experiment **`{}`** created and queued.", name),
+            format!("Experiment **`[{}]({})`** created and queued.", name, host),
         ).set_label(Label::ExperimentQueued)
         .send(&issue.url, data)?;
 
     Ok(())
 }
 
-pub fn edit(data: &Data, issue: &Issue, args: EditArgs) -> Result<()> {
+pub fn edit(host: &str, data: &Data, issue: &Issue, args: EditArgs) -> Result<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
     let changed = ::actions::EditExperiment {
@@ -60,7 +60,7 @@ pub fn edit(data: &Data, issue: &Issue, args: EditArgs) -> Result<()> {
         Message::new()
             .line(
                 "memo",
-                format!("Configuration of the **`{}`** experiment changed.", name),
+                format!("Configuration of the **`[{}]({})`** experiment changed.", name, host),
             ).send(&issue.url, data)?;
     } else {
         Message::new()
@@ -71,14 +71,14 @@ pub fn edit(data: &Data, issue: &Issue, args: EditArgs) -> Result<()> {
     Ok(())
 }
 
-pub fn retry_report(data: &Data, issue: &Issue, args: RetryReportArgs) -> Result<()> {
+pub fn retry_report(host: &str, data: &Data, issue: &Issue, args: RetryReportArgs) -> Result<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
     if let Some(mut experiment) = Experiment::get(&data.db, &name)? {
         if experiment.status != Status::ReportFailed {
             bail!(
-                "generation of the report of the **`{}`** experiment didn't fail!",
-                name
+                "generation of the report of the **`[{}]({})`** experiment didn't fail!",
+                name, host
             );
         }
 
@@ -88,7 +88,7 @@ pub fn retry_report(data: &Data, issue: &Issue, args: RetryReportArgs) -> Result
         Message::new()
             .line(
                 "hammer_and_wrench",
-                format!("Generation of the report for **`{}`** queued again.", name),
+                format!("Generation of the report for **`[{}]({})`** queued again.", name, host),
             ).set_label(Label::ExperimentQueued)
             .send(&issue.url, data)?;
 

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -88,11 +88,11 @@ fn process_command(host: &str, sender: &str, body: &str, issue: &Issue, data: &D
             }
 
             Command::Edit(args) => {
-                commands::edit(host, data, issue, args)?;
+                commands::edit(data, issue, args)?;
             }
 
             Command::RetryReport(args) => {
-                commands::retry_report(host, data, issue, args)?;
+                commands::retry_report(data, issue, args)?;
             }
 
             Command::Abort(args) => {

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -14,7 +14,13 @@ use server::Data;
 use std::sync::Arc;
 use warp::{self, filters::body::FullBody, Filter, Rejection};
 
-fn process_webhook(payload: &[u8], host: &str, signature: &str, event: &str, data: &Data) -> Result<()> {
+fn process_webhook(
+    payload: &[u8],
+    host: &str,
+    signature: &str,
+    event: &str,
+    data: &Data,
+) -> Result<()> {
     if !verify_signature(&data.tokens.bot.webhooks_secret, payload, signature) {
         bail!("invalid signature for the webhook!");
     }
@@ -29,7 +35,8 @@ fn process_webhook(payload: &[u8], host: &str, signature: &str, event: &str, dat
                 return Ok(());
             }
 
-            if let Err(e) = process_command(host, &p.sender.login, &p.comment.body, &p.issue, data) {
+            if let Err(e) = process_command(host, &p.sender.login, &p.comment.body, &p.issue, data)
+            {
                 Message::new()
                     .line("rotating_light", format!("**Error:** {}", e))
                     .note(
@@ -160,7 +167,7 @@ fn receive_endpoint(data: Arc<Data>, headers: HeaderMap, body: FullBody) -> Resu
     let host = headers
         .get("Host")
         .and_then(|h| h.to_str().ok())
-        .ok_or("mission header Host\n")?;
+        .ok_or("missing header Host\n")?;
 
     process_webhook(body.bytes(), host, signature, event, &data)
 }


### PR DESCRIPTION
This pr closes #329 by adding a URL to the report into the create and run comment. It does this using the Host header in the HTTP request and then passes it down to commands::run as an additional argument.

Tested on with my own `craterbot-jr` and a test repo. You can see the correct link created [here](https://github.com/xd009642/bottest-sandbox/issues/1#issuecomment-426766077) though that link will stop working when I the ngrok url runs out!