### PR TITLE
Prevent external network traffic for builds and tests

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -110,7 +110,8 @@ impl<'a> ContainerBuilder<'a> {
         }
 
         if self.networking_disabled {
-            args.push("--network none".into());
+            args.push("--network".into());
+            args.push("none".into());
         }
 
         args.push(self.image.into());

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -52,7 +52,7 @@ pub struct ContainerBuilder<'a> {
     mounts: Vec<MountConfig<'a>>,
     env: Vec<(&'static str, String)>,
     memory_limit: Option<Size>,
-    networking_disabled: bool
+    networking_disabled: bool,
 }
 
 impl<'a> ContainerBuilder<'a> {
@@ -62,7 +62,7 @@ impl<'a> ContainerBuilder<'a> {
             mounts: Vec::new(),
             env: Vec::new(),
             memory_limit: None,
-            networking_disabled: false
+            networking_disabled: false,
         }
     }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -52,6 +52,7 @@ pub struct ContainerBuilder<'a> {
     mounts: Vec<MountConfig<'a>>,
     env: Vec<(&'static str, String)>,
     memory_limit: Option<Size>,
+    networking_disabled: bool
 }
 
 impl<'a> ContainerBuilder<'a> {
@@ -61,6 +62,7 @@ impl<'a> ContainerBuilder<'a> {
             mounts: Vec::new(),
             env: Vec::new(),
             memory_limit: None,
+            networking_disabled: false
         }
     }
 
@@ -83,6 +85,11 @@ impl<'a> ContainerBuilder<'a> {
         self
     }
 
+    pub fn disable_networking(mut self) -> Self {
+        self.networking_disabled = true;
+        self
+    }
+
     pub fn create(self) -> Result<Container> {
         let mut args: Vec<String> = vec!["create".into()];
 
@@ -100,6 +107,10 @@ impl<'a> ContainerBuilder<'a> {
         if let Some(limit) = self.memory_limit {
             args.push("-m".into());
             args.push(limit.to_string());
+        }
+
+        if self.networking_disabled {
+            args.push("--network none".into());
         }
 
         args.push(self.image.into());

--- a/src/ex_prepare.rs
+++ b/src/ex_prepare.rs
@@ -168,8 +168,16 @@ fn capture_lockfile_inner(
         "-Zno-index-update",
     ];
     toolchain
-        .run_cargo(config, ex, path, args, CargoState::Unlocked, false, false, false)
-        .chain_err(|| format!("unable to generate lockfile for {}", krate))?;
+        .run_cargo(
+            config,
+            ex,
+            path,
+            args,
+            CargoState::Unlocked,
+            false,
+            false,
+            false,
+        ).chain_err(|| format!("unable to generate lockfile for {}", krate))?;
 
     let src_lockfile = &path.join("Cargo.lock");
     let dst_lockfile = &lockfile(&ex.name, krate)?;
@@ -230,8 +238,16 @@ pub fn fetch_crate_deps(
 
         let args = &["fetch", "--locked", "--manifest-path", "Cargo.toml"];
         toolchain
-            .run_cargo(config, ex, path, args, CargoState::Unlocked, false, true, false)
-            .chain_err(|| format!("unable to fetch deps for {}", krate))?;
+            .run_cargo(
+                config,
+                ex,
+                path,
+                args,
+                CargoState::Unlocked,
+                false,
+                true,
+                false,
+            ).chain_err(|| format!("unable to fetch deps for {}", krate))?;
 
         Ok(())
     })

--- a/src/ex_prepare.rs
+++ b/src/ex_prepare.rs
@@ -168,7 +168,7 @@ fn capture_lockfile_inner(
         "-Zno-index-update",
     ];
     toolchain
-        .run_cargo(config, ex, path, args, CargoState::Unlocked, false, false)
+        .run_cargo(config, ex, path, args, CargoState::Unlocked, false, false, false)
         .chain_err(|| format!("unable to generate lockfile for {}", krate))?;
 
     let src_lockfile = &path.join("Cargo.lock");
@@ -230,7 +230,7 @@ pub fn fetch_crate_deps(
 
         let args = &["fetch", "--locked", "--manifest-path", "Cargo.toml"];
         toolchain
-            .run_cargo(config, ex, path, args, CargoState::Unlocked, false, true)
+            .run_cargo(config, ex, path, args, CargoState::Unlocked, false, true, false)
             .chain_err(|| format!("unable to fetch deps for {}", krate))?;
 
         Ok(())

--- a/src/ex_run.rs
+++ b/src/ex_run.rs
@@ -67,7 +67,7 @@ fn build(
         CargoState::Locked,
         quiet,
         false,
-        false,
+        true,
     )?;
     toolchain.run_cargo(
         config,

--- a/src/ex_run.rs
+++ b/src/ex_run.rs
@@ -67,6 +67,7 @@ fn build(
         CargoState::Locked,
         quiet,
         false,
+        false,
     )?;
     toolchain.run_cargo(
         config,
@@ -76,6 +77,7 @@ fn build(
         CargoState::Locked,
         quiet,
         false,
+        true,
     )?;
     Ok(())
 }
@@ -95,6 +97,7 @@ fn test(
         CargoState::Locked,
         quiet,
         false,
+        true,
     )
 }
 
@@ -150,6 +153,7 @@ pub fn test_check_only(
         CargoState::Locked,
         quiet,
         false,
+        true,
     );
 
     if r.is_ok() {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -110,6 +110,7 @@ impl Toolchain {
         cargo_state: CargoState,
         quiet: bool,
         unstable_cargo: bool,
+        networking_disabled: bool
     ) -> Result<()> {
         let toolchain_name = self.rustup_name();
         let ex_target_dir = self.target_dir(&ex.name);
@@ -143,6 +144,10 @@ impl Toolchain {
             .env("RUST_BACKTRACE", "full".to_string())
             // Add some limits to the container
             .memory_limit(config.sandbox.memory_limit);
+
+        if networking_disabled {
+            container = container.disable_networking();
+        }
 
         // Set the RUSTFLAGS environment variable
         let mut rustflags = format!("--cap-lints={}", ex.cap_lints.to_str());

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -110,7 +110,7 @@ impl Toolchain {
         cargo_state: CargoState,
         quiet: bool,
         unstable_cargo: bool,
-        networking_disabled: bool
+        networking_disabled: bool,
     ) -> Result<()> {
         let toolchain_name = self.rustup_name();
         let ex_target_dir = self.target_dir(&ex.name);


### PR DESCRIPTION
This PR resolves #281 by disabling docker networking for instances of `run_cargo` where tests are being run, as this could be abused by crates under experiment.