### PR TITLE
Update contributing docs with instructions on running rustfmt and clippy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,3 +130,21 @@ cargo run -- agent http://127.0.0.1:8000 token
 [ngrok]: https://ngrok.com/download
 [minio-play]: https://play.minio.io:9000/
 [minio-client]: https://www.minio.io/downloads.html#download-client
+
+## Submitting your pull request
+
+Before submitting your pull request, you need to lint the code in the project, as otherwise the continuous integration builds will fail.
+
+This project makes use of [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt) and [`clippy`](https://github.com/rust-lang-nursery/rust-clippy) to format the code, and catch common mistakes respectively.
+
+### Installing rustfmt
+
+To install rustfmt, you should follow the [quick start instructions](https://github.com/rust-lang-nursery/rustfmt#quick-start) to install it using the [`rustup`](https://rustup.rs/) tool.
+
+### Installing clippy
+
+To install clippy, you should follow the [usage instruction](https://github.com/rust-lang-nursery/rust-clippy#usage) to install it, either using the [`rustup`](https://rustup.rs/) tool, or using it without installing it.
+
+### Linting your code
+
+To lint the code, run `cargo fmt` to format your code and either `cargo clippy` or `cargo run --bin cargo-clippy --manifest-path=Cargo.toml` to catch common mistakes and improve your code.


### PR DESCRIPTION
As discussed in https://github.com/rust-lang-nursery/crater/pull/336, this PR updates the `CONTRIBUTING.md` docs with instructions on how to install and run [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt) and [`clippy`](https://github.com/rust-lang-nursery/rust-clippy)