### PR TITLE
Make a change to ensure docker is running before experiment starts

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -19,7 +19,7 @@ pub fn build_container(docker_env: &str) -> Result<()> {
         .run()
 }
 
-pub fn is_running() -> bool {
+pub(crate) fn is_running() -> bool {
     RunCommand::new("docker").args(&["info"]).run().is_ok()
 }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -19,6 +19,10 @@ pub fn build_container(docker_env: &str) -> Result<()> {
         .run()
 }
 
+pub fn is_running() -> bool {
+    RunCommand::new("docker").args(&["info"]).run().is_ok()
+}
+
 #[derive(Copy, Clone)]
 pub enum MountPerms {
     ReadWrite,

--- a/src/run_graph.rs
+++ b/src/run_graph.rs
@@ -18,6 +18,7 @@
 
 use config::Config;
 use crossbeam_utils::thread::scope;
+use docker::is_running;
 use errors::*;
 use experiments::{Experiment, Mode};
 use petgraph::{dot::Dot, graph::NodeIndex, stable_graph::StableDiGraph, Direction};
@@ -272,6 +273,10 @@ pub fn run_ex<DB: WriteResults + Sync>(
     threads_count: usize,
     config: &Config,
 ) -> Result<()> {
+    if !is_running() {
+        return Err("docker is not running".into());
+    }
+
     let res = run_ex_inner(ex, db, threads_count, config);
 
     // Remove all the target dirs even if the experiment failed

--- a/src/run_graph.rs
+++ b/src/run_graph.rs
@@ -18,7 +18,6 @@
 
 use config::Config;
 use crossbeam_utils::thread::scope;
-use docker::is_running;
 use errors::*;
 use experiments::{Experiment, Mode};
 use petgraph::{dot::Dot, graph::NodeIndex, stable_graph::StableDiGraph, Direction};
@@ -273,7 +272,7 @@ pub fn run_ex<DB: WriteResults + Sync>(
     threads_count: usize,
     config: &Config,
 ) -> Result<()> {
-    if !is_running() {
+    if !::docker::is_running() {
         return Err("docker is not running".into());
     }
 


### PR DESCRIPTION
Resolves #303

I followed the mentoring instructions, except that I placed the code to check for docker earlier than instructed because it didn't feel necessary for other code to run just for the docker check to fail. Is this okay? 