### PR TITLE
Add mahj to the blacklist

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11167,6 +11167,7 @@ zyre-sys = { skip = true } #automatic
 "moratorium08/blog_os" = { skip = true } #automatic
 "moratorium08/reversi-ai" = { skip-tests = true } #automatic
 "moreorem/graphdener-backend" = { skip = true } #automatic
+"moritayasuaki/mahj" = { skip-tests = true } # outputs 5+GB of data during tests
 "mortonar/rustsysinfo" = { skip = true } #automatic
 "morty-c137-prime/rusty-ricks-cheatsheet" = { skip = true } #automatic
 "motecshine/msgboard" = { skip = true } #automatic


### PR DESCRIPTION
The [moritayasuaki/mahj](https://github.com/moritayasuaki/mahj) GitHub repository has a test that outputs an infinite stream to stdin, and since Crater doesn't limit the size of the logs yet the crate filled the agent's disk.