### PR TITLE
Detect and categorize spurious failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "minifier 0.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1216,6 +1217,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "paste-impl 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1353,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2618,6 +2649,8 @@ dependencies = [
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
+"checksum paste 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "286f1ab82102ffbebd5dbeb9ddf8f2550656b310f547a4097df54e77917207a3"
+"checksum paste-impl 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2c07dfc3b5c356ec19f879bac5b59baf23230e605b4b0ad321e6c8d6e1e59269"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a677051ad923732bb5c70f2d45f8985a96e3eee2e2bff86697e3b11b0c3fcfde"
 "checksum pest_derive 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b76f477146419bc539a63f4ef40e902166cb43b3e51cecc71d9136fd12c567e7"
@@ -2632,6 +2665,7 @@ dependencies = [
 "checksum predicates 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa984b7cd021a0bf5315bcce4c4ae61d2a535db2a8d288fc7578638690a7b7c3"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
 "checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+"checksum proc-macro-hack 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b48022dc205503cfda0955972290462b67e0c9d88ad73f1cf9d7ede7d32efcb6"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "63b5829244f52738cfee93b3a165c1911388675be000c888d2fae620dee8fa5b"
 "checksum r2d2 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d746fc8a0dab19ccea7ff73ad535854e90ddb3b4b8cdce953dd5cd0b2e7bd22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ lazy_static = "1.0"
 mime = "0.3.1"
 minifier = { version = "0.0.20", features = ["html"] }
 nix = "0.11.0"
+paste = "0.1.3"
 petgraph = "0.4.11"
 r2d2 = "0.8.2"
 r2d2_sqlite = "0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ extern crate mime;
 extern crate minifier;
 #[cfg(unix)]
 extern crate nix;
+#[macro_use]
+extern crate paste;
 extern crate petgraph;
 extern crate r2d2;
 extern crate r2d2_sqlite;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,21 @@
+use failure::Context;
 pub use failure::{err_msg, Fail, Fallible, ResultExt};
+
+pub trait FailExt {
+    fn downcast_ctx<T: Fail>(&self) -> Option<&T>;
+}
+
+impl FailExt for dyn Fail {
+    fn downcast_ctx<T: Fail>(&self) -> Option<&T> {
+        if let Some(res) = self.downcast_ref::<T>() {
+            Some(res)
+        } else if let Some(ctx) = self.downcast_ref::<Context<T>>() {
+            Some(ctx.get_context())
+        } else {
+            None
+        }
+    }
+}
 
 macro_rules! to_failure_compat {
     ($($error:path,)*) => {

--- a/src/report/archives.rs
+++ b/src/report/archives.rs
@@ -100,7 +100,7 @@ mod tests {
     use flate2::read::GzDecoder;
     use mime::Mime;
     use report::DummyWriter;
-    use results::{DatabaseDB, TestResult, WriteResults};
+    use results::{DatabaseDB, FailureReason, TestResult, WriteResults};
     use std::io::Read;
     use tar::Archive;
 
@@ -130,7 +130,7 @@ mod tests {
         results
             .record_result(&ex, &ex.toolchains[1], &crate1, || {
                 info!("tc2 crate1");
-                Ok(TestResult::BuildFail)
+                Ok(TestResult::BuildFail(FailureReason::Unknown))
             }).unwrap();
         results
             .record_result(&ex, &ex.toolchains[0], &crate2, || {

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -29,6 +29,8 @@ impl ResultColor for Comparison {
             Comparison::SameTestSkipped => Color::Striped("#72a156", "#80b65f"),
             Comparison::SameTestPass => Color::Single("#72a156"),
             Comparison::Error => Color::Single("#d77026"),
+            Comparison::SpuriousRegressed => Color::Striped("#db3026", "#d5433b"),
+            Comparison::SpuriousFixed => Color::Striped("#5630db", "#5d3dcf"),
         }
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -296,22 +296,22 @@ fn compare(
     use results::TestResult::*;
     match (r1, r2) {
         (Some(res1), Some(res2)) => match (res1, res2) {
-            (BuildFail, BuildFail) => Comparison::SameBuildFail,
-            (TestFail, TestFail) => Comparison::SameTestFail,
+            (BuildFail(_), BuildFail(_)) => Comparison::SameBuildFail,
+            (TestFail(_), TestFail(_)) => Comparison::SameTestFail,
             (TestSkipped, TestSkipped) => Comparison::SameTestSkipped,
             (TestPass, TestPass) => Comparison::SameTestPass,
-            (BuildFail, TestFail)
-            | (BuildFail, TestSkipped)
-            | (BuildFail, TestPass)
-            | (TestFail, TestPass) => Comparison::Fixed,
-            (TestPass, TestFail)
-            | (TestPass, BuildFail)
-            | (TestSkipped, BuildFail)
-            | (TestFail, BuildFail) => Comparison::Regressed,
+            (BuildFail(_), TestFail(_))
+            | (BuildFail(_), TestSkipped)
+            | (BuildFail(_), TestPass)
+            | (TestFail(_), TestPass) => Comparison::Fixed,
+            (TestPass, TestFail(_))
+            | (TestPass, BuildFail(_))
+            | (TestSkipped, BuildFail(_))
+            | (TestFail(_), BuildFail(_)) => Comparison::Regressed,
             (Error, _) | (_, Error) => Comparison::Error,
-            (TestFail, TestSkipped)
+            (TestFail(_), TestSkipped)
             | (TestPass, TestSkipped)
-            | (TestSkipped, TestFail)
+            | (TestSkipped, TestFail(_))
             | (TestSkipped, TestPass) => {
                 panic!("can't compare {} and {}", res1, res2);
             }
@@ -426,7 +426,7 @@ mod tests {
     use config::{Config, CrateConfig};
     use crates::{Crate, GitHubRepo, RegistryCrate};
     use experiments::{CapLints, Experiment, Mode, Status};
-    use results::{DummyDB, TestResult};
+    use results::{DummyDB, FailureReason, TestResult};
     use std::collections::HashMap;
     use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
@@ -515,15 +515,17 @@ mod tests {
 
     #[test]
     fn test_compare() {
+        use results::{FailureReason::*, TestResult::*};
+
         macro_rules! test_compare {
-            ($cmp:ident, $config:expr, $reg:expr, [$($a:ident + $b:ident = $c:ident,)*]) => {
+            ($cmp:ident, $config:expr, $reg:expr, [$($a:expr, $b:expr => $c:ident;)*]) => {
                 $(
                     assert_eq!(
                         $cmp(
                             $config,
                             $reg,
-                            Some(TestResult::$a),
-                            Some(TestResult::$b),
+                            Some($a),
+                            Some($b),
                         ),
                         Comparison::$c
                     );
@@ -542,26 +544,26 @@ mod tests {
             &config,
             &reg,
             [
-                BuildFail + BuildFail = SameBuildFail,
-                TestFail + TestFail = SameTestFail,
-                TestSkipped + TestSkipped = SameTestSkipped,
-                TestPass + TestPass = SameTestPass,
-                BuildFail + TestFail = Fixed,
-                BuildFail + TestSkipped = Fixed,
-                BuildFail + TestPass = Fixed,
-                TestFail + TestPass = Fixed,
-                TestPass + TestFail = Regressed,
-                TestPass + BuildFail = Regressed,
-                TestSkipped + BuildFail = Regressed,
-                TestFail + BuildFail = Regressed,
-                Error + TestPass = Error,
-                Error + TestSkipped = Error,
-                Error + TestFail = Error,
-                Error + BuildFail = Error,
-                TestPass + Error = Error,
-                TestSkipped + Error = Error,
-                TestFail + Error = Error,
-                BuildFail + Error = Error,
+                BuildFail(Unknown), BuildFail(Unknown) => SameBuildFail;
+                TestFail(Unknown), TestFail(Unknown) => SameTestFail;
+                TestSkipped, TestSkipped => SameTestSkipped;
+                TestPass, TestPass => SameTestPass;
+                BuildFail(Unknown), TestFail(Unknown) => Fixed;
+                BuildFail(Unknown), TestSkipped => Fixed;
+                BuildFail(Unknown), TestPass => Fixed;
+                TestFail(Unknown), TestPass => Fixed;
+                TestPass, TestFail(Unknown) => Regressed;
+                TestPass, BuildFail(Unknown) => Regressed;
+                TestSkipped, BuildFail(Unknown) => Regressed;
+                TestFail(Unknown), BuildFail(Unknown) => Regressed;
+                Error, TestPass => Error;
+                Error, TestSkipped => Error;
+                Error, TestFail(Unknown) => Error;
+                Error, BuildFail(Unknown) => Error;
+                TestPass, Error => Error;
+                TestSkipped, Error => Error;
+                TestFail(Unknown), Error => Error;
+                BuildFail(Unknown), Error => Error;
             ]
         );
 
@@ -618,7 +620,7 @@ mod tests {
             &ex,
             gh.clone(),
             TEST_TOOLCHAIN.clone(),
-            TestResult::BuildFail,
+            TestResult::BuildFail(FailureReason::Unknown),
         );
         db.add_dummy_log(
             &ex,
@@ -668,7 +670,7 @@ mod tests {
         );
         assert_eq!(
             (&crate_result.runs[1]).as_ref().unwrap().res,
-            TestResult::BuildFail
+            TestResult::BuildFail(FailureReason::Unknown)
         );
         assert_eq!(
             (&crate_result.runs[0]).as_ref().unwrap().log.as_str(),

--- a/src/results/db.rs
+++ b/src/results/db.rs
@@ -66,7 +66,7 @@ impl<'a> DatabaseDB<'a> {
                 &ex.name,
                 &serde_json::to_string(krate)?,
                 &toolchain.to_string(),
-                &res.to_str(),
+                &res.to_string(),
                 &log,
             ],
         )?;
@@ -211,7 +211,7 @@ mod tests {
     use crates::{Crate, GitHubRepo, RegistryCrate};
     use db::Database;
     use experiments::Experiment;
-    use results::{DeleteResults, ReadResults, TestResult, WriteResults};
+    use results::{DeleteResults, FailureReason, ReadResults, TestResult, WriteResults};
     use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
     #[test]
@@ -345,11 +345,11 @@ mod tests {
         results
             .record_result(&ex, &TEST_TOOLCHAIN, &krate, || {
                 info!("Another log message!");
-                Ok(TestResult::TestFail)
+                Ok(TestResult::TestFail(FailureReason::Unknown))
             }).unwrap();
         assert_eq!(
             results.get_result(&ex, &TEST_TOOLCHAIN, &krate).unwrap(),
-            Some(TestResult::TestFail)
+            Some(TestResult::TestFail(FailureReason::Unknown))
         );
 
         // Test deleting the newly-added result

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -115,6 +115,15 @@ string_enum!(pub enum FailureReason {
     Timeout => "timeout",
 });
 
+impl FailureReason {
+    pub(crate) fn is_spurious(self) -> bool {
+        match self {
+            FailureReason::Unknown | FailureReason::Broken => false,
+            FailureReason::OOM | FailureReason::Timeout => true,
+        }
+    }
+}
+
 test_result_enum!(pub enum TestResult {
     with_reason {
         BuildFail(FailureReason) => "build-fail",

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -9,6 +9,7 @@ pub use results::db::{DatabaseDB, ProgressData};
 #[cfg(test)]
 pub use results::dummy::DummyDB;
 use std::collections::HashMap;
+use std::{fmt, str::FromStr};
 use toolchain::Toolchain;
 
 pub trait ReadResults {
@@ -51,10 +52,124 @@ pub trait DeleteResults {
     fn delete_result(&self, ex: &Experiment, toolchain: &Toolchain, krate: &Crate) -> Fallible<()>;
 }
 
-string_enum!(pub enum TestResult {
-    BuildFail => "build-fail",
-    TestFail => "test-fail",
-    TestSkipped => "test-skipped",
-    TestPass => "test-pass",
-    Error => "error",
+macro_rules! test_result_enum {
+    (pub enum $name:ident {
+        with_reason { $($with_reason_name:ident(FailureReason) => $with_reason_repr:expr,)* }
+        without_reason { $($reasonless_name:ident => $reasonless_repr:expr,)* }
+    }) => {
+        #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+        pub enum $name {
+            $($with_reason_name(FailureReason),)*
+            $($reasonless_name,)*
+        }
+
+        impl FromStr for $name {
+            type Err = ::failure::Error;
+
+            fn from_str(input: &str) -> Fallible<Self> {
+                let parts: Vec<&str> = input.split(':').collect();
+
+                if parts.len() == 1 {
+                    match parts[0] {
+                        $($with_reason_repr => Ok($name::$with_reason_name(FailureReason::Unknown)),)*
+                        $($reasonless_repr => Ok($name::$reasonless_name),)*
+                        other => Err(TestResultParseError::UnknownResult(other.into()).into()),
+                    }
+                } else if parts.len() == 2 {
+                    match parts[0] {
+                        $($reasonless_repr => Err(TestResultParseError::UnexpectedFailureReason.into()),)*
+                        $($with_reason_repr => Ok($name::$with_reason_name(parts[1].parse()?)),)*
+                        other => Err(TestResultParseError::UnknownResult(other.into()).into()),
+                    }
+                } else {
+                    Err(TestResultParseError::TooManySegments.into())
+                }
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match self {
+                    $($name::$with_reason_name(reason) => write!(f, "{}:{}", $with_reason_repr, reason),)*
+                    $($name::$reasonless_name => write!(f, "{}", $reasonless_repr),)*
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Fail)]
+pub enum TestResultParseError {
+    #[fail(display = "unknown test result: {}", _0)]
+    UnknownResult(String),
+    #[fail(display = "unexpected failure reason")]
+    UnexpectedFailureReason,
+    #[fail(display = "too many segments")]
+    TooManySegments,
+}
+
+string_enum!(pub enum FailureReason {
+    Unknown => "unknown",
+    Broken => "broken",
+    OOM => "oom",
+    Timeout => "timeout",
 });
+
+test_result_enum!(pub enum TestResult {
+    with_reason {
+        BuildFail(FailureReason) => "build-fail",
+        TestFail(FailureReason) => "test-fail",
+    }
+    without_reason {
+        TestSkipped => "test-skipped",
+        TestPass => "test-pass",
+        Error => "error",
+    }
+});
+
+impl_serde_from_parse!(TestResult, expecting = "a test result");
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    #[test]
+    fn test_test_result_parsing() {
+        use super::{
+            FailureReason::*,
+            TestResult::{self, *},
+        };
+
+        macro_rules! test_from_str {
+            ($($str:expr => $rust:expr,)*) => {
+                $(
+                    // Test parsing from string to rust
+                    assert_eq!(TestResult::from_str($str).unwrap(), $rust);
+
+                    // Test dumping from rust to string
+                    assert_eq!(&$rust.to_string(), $str);
+
+                    // Test dumping from rust to string to rust
+                    assert_eq!(TestResult::from_str($rust.to_string().as_ref()).unwrap(), $rust);
+                )*
+            };
+        }
+
+        test_from_str! {
+            "build-fail:unknown" => BuildFail(Unknown),
+            "build-fail:oom" => BuildFail(OOM),
+            "test-fail:timeout" => TestFail(Timeout),
+            "test-pass" => TestPass,
+            "error" => Error,
+        }
+
+        // Backward compatibility
+        assert_eq!(
+            TestResult::from_str("build-fail").unwrap(),
+            BuildFail(Unknown)
+        );
+
+        assert!(TestResult::from_str("error:oom").is_err());
+        assert!(TestResult::from_str("build-fail:pleasedonotaddthis").is_err());
+    }
+}

--- a/src/runner/prepare.rs
+++ b/src/runner/prepare.rs
@@ -3,7 +3,7 @@ use crates::Crate;
 use dirs::{EXPERIMENT_DIR, TEST_SOURCE_DIR};
 use experiments::Experiment;
 use prelude::*;
-use results::{TestResult, WriteResults};
+use results::{FailureReason, TestResult, WriteResults};
 use run::RunCommand;
 use runner::toml_frobber::TomlFrobber;
 use runner::OverrideResult;
@@ -103,7 +103,7 @@ pub(super) fn validate_manifest(ex: &Experiment, krate: &Crate, tc: &Toolchain) 
             .hide_output(true)
             .run()
             .with_context(|_| format!("invalid syntax in {}'s Cargo.toml", krate))
-            .with_context(|_| OverrideResult(TestResult::BuildFail))?;
+            .with_context(|_| OverrideResult(TestResult::BuildFail(FailureReason::Broken)))?;
 
         Ok(())
     })

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -1,7 +1,7 @@
 macro_rules! string_enum {
-    (pub enum $name:ident { $($item:ident => $str:expr,)* }) => {
-        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Copy, Clone)]
-        pub enum $name {
+    ($vis:vis enum $name:ident { $($item:ident => $str:expr,)* }) => {
+        #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+        $vis enum $name {
             $($item,)*
         }
 
@@ -23,16 +23,20 @@ macro_rules! string_enum {
         }
 
         impl $name {
-            pub fn to_str(&self) -> &'static str {
+            #[allow(dead_code)]
+            $vis fn to_str(&self) -> &'static str {
                 match *self {
                     $($name::$item => $str,)*
                 }
             }
 
-            pub fn possible_values() -> &'static [&'static str] {
+            #[allow(dead_code)]
+            $vis fn possible_values() -> &'static [&'static str] {
                 &[$($str,)*]
             }
         }
+
+        impl_serde_from_parse!($name, expecting="foo");
     }
 }
 
@@ -49,6 +53,7 @@ macro_rules! impl_serde_from_parse {
                 }
 
                 fn visit_str<E: ::serde::de::Error>(self, input: &str) -> Result<$for, E> {
+                    use std::str::FromStr;
                     $for::from_str(input).map_err(E::custom)
                 }
             }

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -35,3 +35,41 @@ macro_rules! string_enum {
         }
     }
 }
+
+macro_rules! impl_serde_from_parse {
+    ($for:ident, expecting=$expecting:expr) => {
+        item! {
+            struct [<$for Visitor>];
+
+            impl<'de> ::serde::de::Visitor<'de> for [<$for Visitor>] {
+                type Value = $for;
+
+                fn expecting(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    f.write_str($expecting)
+                }
+
+                fn visit_str<E: ::serde::de::Error>(self, input: &str) -> Result<$for, E> {
+                    $for::from_str(input).map_err(E::custom)
+                }
+            }
+        }
+
+        impl<'de> ::serde::de::Deserialize<'de> for $for {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: ::serde::de::Deserializer<'de>,
+            {
+                deserializer.deserialize_str(expr! { [<$for Visitor>] })
+            }
+        }
+
+        impl ::serde::ser::Serialize for $for {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: ::serde::ser::Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+    };
+}

--- a/src/utils/size.rs
+++ b/src/utils/size.rs
@@ -1,8 +1,4 @@
 use prelude::*;
-use serde::{
-    de::{Deserialize, Deserializer, Error as DeError, Visitor},
-    ser::{Serialize, Serializer},
-};
 use std::fmt;
 use std::str::FromStr;
 
@@ -53,31 +49,7 @@ impl FromStr for Size {
     }
 }
 
-struct SizeVisitor;
-
-impl<'de> Visitor<'de> for SizeVisitor {
-    type Value = Size;
-
-    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("a size")
-    }
-
-    fn visit_str<E: DeError>(self, input: &str) -> Result<Size, E> {
-        Size::from_str(input).map_err(E::custom)
-    }
-}
-
-impl<'de> Deserialize<'de> for Size {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Size, D::Error> {
-        deserializer.deserialize_str(SizeVisitor)
-    }
-}
-
-impl Serialize for Size {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.to_string())
-    }
-}
+impl_serde_from_parse!(Size, expecting = "a size");
 
 #[cfg(test)]
 mod tests {

--- a/templates/report/results.html
+++ b/templates/report/results.html
@@ -5,7 +5,7 @@
 {% block extra_head %}
     <style>
         {% for name, color in result_colors %}
-            .cr-{{ name }} {
+            .cr-{{ name|replace(from=":", to="\:") }} {
                 {% if color.Single %}
                     background: {{ color.Single }};
                 {% elif color.Striped %}
@@ -42,7 +42,9 @@
                             <span class="run">
                                 {% if run %}
                                     <b class="cr-{{ run.res }}"></b>
-                                    <a href="{{ run.log|safe }}/log.txt">{{ run.res }}</a>
+                                    <a href="{{ run.log|safe }}/log.txt">
+                                        {{ result_names[run.res] }}
+                                    </a>
                                 {% else %}
                                     <b class="cc-{{ crate.res }}"></b>
                                     {{ crate.res }}

--- a/tests/minicrater/full/results.expected.json
+++ b/tests/minicrater/full/results.expected.json
@@ -6,11 +6,11 @@
       "runs": [
         {
           "log": "stable/local/beta-fixed",
-          "res": "BuildFail"
+          "res": "build-fail:unknown"
         },
         {
           "log": "beta/local/beta-fixed",
-          "res": "TestPass"
+          "res": "test-pass"
         }
       ],
       "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/beta-fixed"
@@ -21,11 +21,11 @@
       "runs": [
         {
           "log": "stable/local/beta-regression",
-          "res": "TestPass"
+          "res": "test-pass"
         },
         {
           "log": "beta/local/beta-regression",
-          "res": "BuildFail"
+          "res": "build-fail:unknown"
         }
       ],
       "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/beta-regression"
@@ -36,11 +36,11 @@
       "runs": [
         {
           "log": "stable/local/broken-cargotoml",
-          "res": "BuildFail"
+          "res": "build-fail:broken"
         },
         {
           "log": "beta/local/broken-cargotoml",
-          "res": "BuildFail"
+          "res": "build-fail:broken"
         }
       ],
       "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/broken-cargotoml"
@@ -51,11 +51,11 @@
       "runs": [
         {
           "log": "stable/local/build-fail",
-          "res": "BuildFail"
+          "res": "build-fail:unknown"
         },
         {
           "log": "beta/local/build-fail",
-          "res": "BuildFail"
+          "res": "build-fail:unknown"
         }
       ],
       "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-fail"
@@ -66,11 +66,11 @@
       "runs": [
         {
           "log": "stable/local/build-pass",
-          "res": "TestPass"
+          "res": "test-pass"
         },
         {
           "log": "beta/local/build-pass",
-          "res": "TestPass"
+          "res": "test-pass"
         }
       ],
       "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-pass"
@@ -81,11 +81,11 @@
       "runs": [
         {
           "log": "stable/local/memory-hungry",
-          "res": "BuildFail"
+          "res": "build-fail:oom"
         },
         {
           "log": "beta/local/memory-hungry",
-          "res": "TestFail"
+          "res": "test-fail:oom"
         }
       ],
       "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/memory-hungry"
@@ -96,11 +96,11 @@
       "runs": [
         {
           "log": "stable/local/network-access",
-          "res": "BuildFail"
+          "res": "build-fail:unknown"
         },
         {
           "log": "beta/local/network-access",
-          "res": "TestFail"
+          "res": "test-fail:unknown"
         }
       ],
       "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/network-access"
@@ -111,11 +111,11 @@
       "runs": [
         {
           "log": "stable/local/test-fail",
-          "res": "TestFail"
+          "res": "test-fail:unknown"
         },
         {
           "log": "beta/local/test-fail",
-          "res": "TestFail"
+          "res": "test-fail:unknown"
         }
       ],
       "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/test-fail"

--- a/tests/minicrater/full/results.expected.json
+++ b/tests/minicrater/full/results.expected.json
@@ -2,7 +2,7 @@
   "crates": [
     {
       "name": "beta-fixed (local)",
-      "res": "Fixed",
+      "res": "fixed",
       "runs": [
         {
           "log": "stable/local/beta-fixed",
@@ -17,7 +17,7 @@
     },
     {
       "name": "beta-regression (local)",
-      "res": "Regressed",
+      "res": "regressed",
       "runs": [
         {
           "log": "stable/local/beta-regression",
@@ -32,7 +32,7 @@
     },
     {
       "name": "broken-cargotoml (local)",
-      "res": "SameBuildFail",
+      "res": "build-fail",
       "runs": [
         {
           "log": "stable/local/broken-cargotoml",
@@ -47,7 +47,7 @@
     },
     {
       "name": "build-fail (local)",
-      "res": "SameBuildFail",
+      "res": "build-fail",
       "runs": [
         {
           "log": "stable/local/build-fail",
@@ -62,7 +62,7 @@
     },
     {
       "name": "build-pass (local)",
-      "res": "SameTestPass",
+      "res": "test-pass",
       "runs": [
         {
           "log": "stable/local/build-pass",
@@ -77,7 +77,7 @@
     },
     {
       "name": "memory-hungry (local)",
-      "res": "Fixed",
+      "res": "spurious-fixed",
       "runs": [
         {
           "log": "stable/local/memory-hungry",
@@ -92,7 +92,7 @@
     },
     {
       "name": "network-access (local)",
-      "res": "Fixed",
+      "res": "fixed",
       "runs": [
         {
           "log": "stable/local/network-access",
@@ -107,7 +107,7 @@
     },
     {
       "name": "test-fail (local)",
-      "res": "SameTestFail",
+      "res": "test-fail",
       "runs": [
         {
           "log": "stable/local/test-fail",

--- a/tests/minicrater/small/results.expected.json
+++ b/tests/minicrater/small/results.expected.json
@@ -6,11 +6,11 @@
       "runs": [
         {
           "log": "stable/local/beta-regression",
-          "res": "TestPass"
+          "res": "test-pass"
         },
         {
           "log": "beta/local/beta-regression",
-          "res": "BuildFail"
+          "res": "build-fail:unknown"
         }
       ],
       "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/beta-regression"
@@ -21,11 +21,11 @@
       "runs": [
         {
           "log": "stable/local/build-pass",
-          "res": "TestPass"
+          "res": "test-pass"
         },
         {
           "log": "beta/local/build-pass",
-          "res": "TestPass"
+          "res": "test-pass"
         }
       ],
       "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-pass"

--- a/tests/minicrater/small/results.expected.json
+++ b/tests/minicrater/small/results.expected.json
@@ -2,7 +2,7 @@
   "crates": [
     {
       "name": "beta-regression (local)",
-      "res": "Regressed",
+      "res": "regressed",
       "runs": [
         {
           "log": "stable/local/beta-regression",
@@ -17,7 +17,7 @@
     },
     {
       "name": "build-pass (local)",
-      "res": "SameTestPass",
+      "res": "test-pass",
       "runs": [
         {
           "log": "stable/local/build-pass",


### PR DESCRIPTION
This PR automatically detects and reports OOMs and timeouts:

![screenshot from 2018-11-10 10-58-03](https://user-images.githubusercontent.com/2299951/48300828-fee61200-e4e3-11e8-9bab-697878b6989d.png)

It also categorizes them as spurious when they are regressions/fixes:

![screenshot from 2018-11-10 12-23-23](https://user-images.githubusercontent.com/2299951/48300827-fee61200-e4e3-11e8-851f-70fa95f07569.png)