### PR TITLE
Add support for rustdoc runs

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -67,6 +67,7 @@ The following experiment modes are currently available:
 * `build-and-test`: run `cargo build` and `cargo test` on every crate
 * `build-only`: run `cargo build` on every crate
 * `check-only`: run `cargo check` on every crate (faster)
+* `rustdoc`: run `cargo doc --no-deps` on every crate
 
 The mode you should use depends on what your experiment is testing:
 

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -21,6 +21,7 @@ string_enum!(pub enum Mode {
     BuildAndTest => "build-and-test",
     BuildOnly => "build-only",
     CheckOnly => "check-only",
+    Rustdoc => "rustdoc",
     UnstableFeatures => "unstable-features",
 });
 

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -255,6 +255,10 @@ pub(super) fn build_graph(ex: &Experiment, config: &Config) -> TasksGraph {
                             tc: tc.clone(),
                             quiet,
                         },
+                        Mode::Rustdoc => TaskStep::Rustdoc {
+                            tc: tc.clone(),
+                            quiet,
+                        },
                         Mode::UnstableFeatures => TaskStep::UnstableFeatures { tc: tc.clone() },
                     },
                 },

--- a/src/runner/tasks.rs
+++ b/src/runner/tasks.rs
@@ -14,6 +14,7 @@ pub(super) enum TaskStep {
     BuildAndTest { tc: Toolchain, quiet: bool },
     BuildOnly { tc: Toolchain, quiet: bool },
     CheckOnly { tc: Toolchain, quiet: bool },
+    Rustdoc { tc: Toolchain, quiet: bool },
     UnstableFeatures { tc: Toolchain },
 }
 
@@ -35,6 +36,12 @@ impl fmt::Debug for TaskStep {
             }
             TaskStep::CheckOnly { ref tc, quiet } => {
                 write!(f, "check {}", tc.to_string())?;
+                if quiet {
+                    write!(f, " (quiet)")?;
+                }
+            }
+            TaskStep::Rustdoc { ref tc, quiet } => {
+                write!(f, "doc {}", tc.to_string())?;
                 if quiet {
                     write!(f, " (quiet)")?;
                 }
@@ -71,6 +78,7 @@ impl Task {
             TaskStep::BuildAndTest { ref tc, .. }
             | TaskStep::BuildOnly { ref tc, .. }
             | TaskStep::CheckOnly { ref tc, .. }
+            | TaskStep::Rustdoc { ref tc, .. }
             | TaskStep::UnstableFeatures { ref tc } => {
                 db.get_result(ex, tc, &self.krate).unwrap_or(None).is_none()
             }
@@ -89,6 +97,7 @@ impl Task {
             TaskStep::BuildAndTest { ref tc, .. }
             | TaskStep::BuildOnly { ref tc, .. }
             | TaskStep::CheckOnly { ref tc, .. }
+            | TaskStep::Rustdoc { ref tc, .. }
             | TaskStep::UnstableFeatures { ref tc } => {
                 db.record_result(ex, tc, &self.krate, || {
                     error!("this task or one of its parent failed!");
@@ -114,6 +123,7 @@ impl Task {
             }
             TaskStep::BuildOnly { ref tc, quiet } => self.run_build_only(config, ex, tc, db, quiet),
             TaskStep::CheckOnly { ref tc, quiet } => self.run_check_only(config, ex, tc, db, quiet),
+            TaskStep::Rustdoc { ref tc, quiet } => self.run_rustdoc(config, ex, tc, db, quiet),
             TaskStep::UnstableFeatures { ref tc } => self.run_unstable_features(config, ex, db, tc),
         }
     }
@@ -196,6 +206,26 @@ impl Task {
             db,
             quiet,
             test::test_check_only,
+        ).map(|_| ())
+    }
+
+    fn run_rustdoc<DB: WriteResults>(
+        &self,
+        config: &Config,
+        ex: &Experiment,
+        tc: &Toolchain,
+        db: &DB,
+        quiet: bool,
+    ) -> Fallible<()> {
+        test::run_test(
+            config,
+            "documenting",
+            ex,
+            tc,
+            &self.krate,
+            db,
+            quiet,
+            test::test_rustdoc,
         ).map(|_| ())
     }
 

--- a/src/server/routes/ui/experiments.rs
+++ b/src/server/routes/ui/experiments.rs
@@ -38,6 +38,7 @@ impl ExperimentData {
                 Mode::BuildAndTest => "cargo test",
                 Mode::BuildOnly => "cargo build",
                 Mode::CheckOnly => "cargo check",
+                Mode::Rustdoc => "cargo doc",
                 Mode::UnstableFeatures => "unstable features",
             },
             assigned_to: experiment.assigned_to.as_ref().map(|a| a.to_string()),


### PR DESCRIPTION
This PR adds a new kind of Crater run, `rustdoc`, which runs `cargo doc` on all the crates.

Fixes #357 