### PR TITLE
Allow rustdoc team to interact with craterbot

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,7 @@ bot-acl = [
     "rust-lang/release",
     "rust-lang/compiler",
     "rust-lang/libs",
+    "rust-lang/rustdoc",
 ]
 
 [server.labels]


### PR DESCRIPTION
Now that Crater supports rustdoc runs, let's give the rustdoc team the ability to start runs on their own. [Documentation on how to start a run](https://github.com/rust-lang-nursery/crater/blob/master/docs/bot-usage.md).

cc @rust-lang-nursery/rustdoc 