### PR TITLE
Properly mark crates without Cargo.toml as failed

### DIFF
--- a/src/runner/prepare.rs
+++ b/src/runner/prepare.rs
@@ -97,6 +97,12 @@ pub(super) fn with_frobbed_toml(ex: &Experiment, krate: &Crate, path: &Path) -> 
 pub(super) fn validate_manifest(ex: &Experiment, krate: &Crate, tc: &Toolchain) -> Fallible<()> {
     info!("validating manifest of {} on toolchain {}", krate, tc);
     with_work_crate(ex, tc, krate, |path| {
+        // Skip crates missing a Cargo.toml
+        if !path.join("Cargo.toml").is_file() {
+            Err(err_msg(format!("missing Cargo.toml for {}", krate)))
+                .with_context(|_| OverrideResult(TestResult::BuildFail(FailureReason::Broken)))?;
+        }
+
         RunCommand::new(CARGO.toolchain(tc))
             .args(&["read-manifest", "--manifest-path", "Cargo.toml"])
             .cd(path)

--- a/src/runner/tasks.rs
+++ b/src/runner/tasks.rs
@@ -141,8 +141,8 @@ impl Task {
             ::runner::prepare::capture_shas(ex, &[self.krate.clone()], db)?;
         }
 
-        ::runner::prepare::frob_toml(ex, &self.krate)?;
         ::runner::prepare::validate_manifest(ex, &self.krate, &ex.toolchains[0])?;
+        ::runner::prepare::frob_toml(ex, &self.krate)?;
         ::runner::prepare::capture_lockfile(config, ex, &self.krate, &ex.toolchains[0])?;
         ::runner::prepare::fetch_crate_deps(config, ex, &self.krate, &ex.toolchains[0])?;
 


### PR DESCRIPTION
Before this PR they would be marked as error.