### PR TITLE
Migrate to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "crater"
 version = "0.1.0"
-authors = ["Brian Anderson <banderson@mozilla.com>"]
+authors = [
+    "Brian Anderson <banderson@mozilla.com>",
+    "Pietro Albini <pietro@pietroalbini.org>",
+]
+edition = "2018"
 
 build = "build.rs"
 

--- a/src/actions/experiments/create.rs
+++ b/src/actions/experiments/create.rs
@@ -1,10 +1,10 @@
-use actions::experiments::ExperimentError;
+use crate::actions::experiments::ExperimentError;
+use crate::config::Config;
+use crate::db::{Database, QueryUtils};
+use crate::experiments::{CapLints, CrateSelect, Experiment, GitHubIssue, Mode, Status};
+use crate::prelude::*;
+use crate::toolchain::Toolchain;
 use chrono::Utc;
-use config::Config;
-use db::{Database, QueryUtils};
-use experiments::{CapLints, CrateSelect, Experiment, GitHubIssue, Mode, Status};
-use prelude::*;
-use toolchain::Toolchain;
 
 pub struct CreateExperiment {
     pub name: String,
@@ -19,7 +19,7 @@ pub struct CreateExperiment {
 impl CreateExperiment {
     #[cfg(test)]
     pub fn dummy(name: &str) -> Self {
-        use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
+        use crate::toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
         CreateExperiment {
             name: name.to_string(),
@@ -43,7 +43,7 @@ impl CreateExperiment {
             return Err(ExperimentError::DuplicateToolchains.into());
         }
 
-        let crates = ::crates::lists::get_crates(self.crates, db, config)?;
+        let crates = crate::crates::lists::get_crates(self.crates, db, config)?;
 
         db.transaction(|transaction| {
             transaction.execute(
@@ -84,18 +84,18 @@ impl CreateExperiment {
 #[cfg(test)]
 mod tests {
     use super::CreateExperiment;
-    use actions::ExperimentError;
-    use config::Config;
-    use db::Database;
-    use experiments::{CapLints, CrateSelect, Experiment, GitHubIssue, Mode, Status};
-    use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
+    use crate::actions::ExperimentError;
+    use crate::config::Config;
+    use crate::db::Database;
+    use crate::experiments::{CapLints, CrateSelect, Experiment, GitHubIssue, Mode, Status};
+    use crate::toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
     #[test]
     fn test_creation() {
         let db = Database::temp().unwrap();
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         let api_url = "https://api.github.com/repos/example/example/issues/10";
         let html_url = "https://github.com/example/example/issue/10";
@@ -125,7 +125,7 @@ mod tests {
         assert_eq!(ex.mode, Mode::BuildAndTest);
         assert_eq!(
             ex.crates,
-            ::crates::lists::get_crates(CrateSelect::Local, &db, &config).unwrap()
+            crate::crates::lists::get_crates(CrateSelect::Local, &db, &config).unwrap()
         );
         assert_eq!(ex.cap_lints, CapLints::Forbid);
         assert_eq!(ex.github_issue.as_ref().unwrap().api_url.as_str(), api_url);
@@ -144,7 +144,7 @@ mod tests {
         let db = Database::temp().unwrap();
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // Ensure an experiment with duplicate toolchains can't be created
         let err = CreateExperiment {
@@ -170,7 +170,7 @@ mod tests {
         let db = Database::temp().unwrap();
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // The first experiment can be created successfully
         CreateExperiment {

--- a/src/actions/experiments/delete.rs
+++ b/src/actions/experiments/delete.rs
@@ -1,8 +1,8 @@
-use actions::experiments::ExperimentError;
-use config::Config;
-use db::{Database, QueryUtils};
-use experiments::Experiment;
-use prelude::*;
+use crate::actions::experiments::ExperimentError;
+use crate::config::Config;
+use crate::db::{Database, QueryUtils};
+use crate::experiments::Experiment;
+use crate::prelude::*;
 
 pub struct DeleteExperiment {
     pub name: String,
@@ -25,10 +25,10 @@ impl DeleteExperiment {
 #[cfg(test)]
 mod tests {
     use super::DeleteExperiment;
-    use actions::{CreateExperiment, ExperimentError};
-    use config::Config;
-    use db::Database;
-    use experiments::Experiment;
+    use crate::actions::{CreateExperiment, ExperimentError};
+    use crate::config::Config;
+    use crate::db::Database;
+    use crate::experiments::Experiment;
 
     #[test]
     fn test_delete_missing_experiment() {
@@ -52,7 +52,7 @@ mod tests {
         let db = Database::temp().unwrap();
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // Create a dummy experiment and make sure it exists
         CreateExperiment::dummy("dummy")

--- a/src/actions/experiments/edit.rs
+++ b/src/actions/experiments/edit.rs
@@ -1,9 +1,9 @@
-use actions::experiments::ExperimentError;
-use config::Config;
-use db::{Database, QueryUtils};
-use experiments::{CapLints, CrateSelect, Experiment, Mode, Status};
-use prelude::*;
-use toolchain::Toolchain;
+use crate::actions::experiments::ExperimentError;
+use crate::config::Config;
+use crate::db::{Database, QueryUtils};
+use crate::experiments::{CapLints, CrateSelect, Experiment, Mode, Status};
+use crate::prelude::*;
+use crate::toolchain::Toolchain;
 
 pub struct EditExperiment {
     pub name: String,
@@ -63,7 +63,7 @@ impl EditExperiment {
 
             // Try to update the list of crates
             if let Some(crates) = self.crates {
-                let crates_vec = ::crates::lists::get_crates(crates, db, config)?;
+                let crates_vec = crate::crates::lists::get_crates(crates, db, config)?;
 
                 // Recreate the list of crates without checking if it was the same
                 // This is done to allow reloading the list of crates in an existing experiment
@@ -131,18 +131,18 @@ impl EditExperiment {
 #[cfg(test)]
 mod tests {
     use super::EditExperiment;
-    use actions::{CreateExperiment, ExperimentError};
-    use config::Config;
-    use db::Database;
-    use experiments::{CapLints, CrateSelect, Experiment, Mode, Status};
-    use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
+    use crate::actions::{CreateExperiment, ExperimentError};
+    use crate::config::Config;
+    use crate::db::Database;
+    use crate::experiments::{CapLints, CrateSelect, Experiment, Mode, Status};
+    use crate::toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
     #[test]
     fn test_edit_with_no_changes() {
         let db = Database::temp().unwrap();
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // Create a dummy experiment to edit
         CreateExperiment::dummy("foo").apply(&db, &config).unwrap();
@@ -157,7 +157,7 @@ mod tests {
         let db = Database::temp().unwrap();
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // Create an experiment with the data we're going to change
         CreateExperiment {
@@ -198,7 +198,7 @@ mod tests {
 
         assert_eq!(
             ex.crates,
-            ::crates::lists::get_crates(CrateSelect::Local, &db, &config).unwrap()
+            crate::crates::lists::get_crates(CrateSelect::Local, &db, &config).unwrap()
         );
     }
 
@@ -207,7 +207,7 @@ mod tests {
         let db = Database::temp().unwrap();
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // First create an experiment
         let mut dummy = CreateExperiment::dummy("foo");
@@ -230,7 +230,7 @@ mod tests {
         let db = Database::temp().unwrap();
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         let err = EditExperiment::dummy("foo")
             .apply(&db, &config)
@@ -246,7 +246,7 @@ mod tests {
         let db = Database::temp().unwrap();
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // Create an experiment and set it to running
         CreateExperiment::dummy("foo").apply(&db, &config).unwrap();

--- a/src/actions/experiments/mod.rs
+++ b/src/actions/experiments/mod.rs
@@ -6,7 +6,7 @@ pub use self::create::CreateExperiment;
 pub use self::delete::DeleteExperiment;
 pub use self::edit::EditExperiment;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, failure::Fail)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum ExperimentError {
     #[fail(display = "experiment '{}' not found", _0)]

--- a/src/actions/lists/update.rs
+++ b/src/actions/lists/update.rs
@@ -1,7 +1,7 @@
-use config::Config;
-use crates::lists::{GitHubList, List, LocalList, RegistryList};
-use db::Database;
-use prelude::*;
+use crate::config::Config;
+use crate::crates::lists::{GitHubList, List, LocalList, RegistryList};
+use crate::db::Database;
+use crate::prelude::*;
 
 pub struct UpdateLists {
     pub github: bool,

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -1,14 +1,15 @@
+use crate::crates::{Crate, GitHubRepo};
+use crate::experiments::Experiment;
+use crate::prelude::*;
+use crate::results::TestResult;
+use crate::server::api_types::{AgentConfig, ApiResponse, CraterToken};
+use crate::toolchain::Toolchain;
+use crate::utils;
 use base64;
-use crates::{Crate, GitHubRepo};
-use experiments::Experiment;
 use http::{header::AUTHORIZATION, Method, StatusCode};
-use prelude::*;
 use reqwest::RequestBuilder;
-use results::TestResult;
 use serde::de::DeserializeOwned;
-use server::api_types::{AgentConfig, ApiResponse, CraterToken};
-use toolchain::Toolchain;
-use utils::http;
+use serde_json::json;
 
 #[derive(Debug, Fail)]
 pub enum AgentApiError {
@@ -75,7 +76,7 @@ impl AgentApi {
     }
 
     fn build_request(&self, method: Method, url: &str) -> RequestBuilder {
-        http::prepare_sync(method, &format!("{}/agent-api/{}", self.url, url)).header(
+        utils::http::prepare_sync(method, &format!("{}/agent-api/{}", self.url, url)).header(
             AUTHORIZATION,
             (CraterToken {
                 token: self.token.clone(),

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,13 +1,13 @@
 mod api;
 mod results;
 
-use agent::api::AgentApi;
-use config::Config;
-use experiments::Experiment;
-use prelude::*;
+use crate::agent::api::AgentApi;
+use crate::config::Config;
+use crate::experiments::Experiment;
+use crate::prelude::*;
+use crate::utils;
 use std::thread;
 use std::time::Duration;
-use utils;
 
 struct Agent {
     api: AgentApi,
@@ -55,7 +55,7 @@ pub fn run(url: &str, token: &str, threads_count: usize, docker_env: &str) -> Fa
 
     loop {
         let ex = agent.experiment()?;
-        ::runner::run_ex(&ex, &db, threads_count, &agent.config, docker_env)?;
+        crate::runner::run_ex(&ex, &db, threads_count, &agent.config, docker_env)?;
         agent.api.complete_experiment()?;
     }
 }

--- a/src/agent/results.rs
+++ b/src/agent/results.rs
@@ -1,13 +1,13 @@
-use agent::api::AgentApi;
-use crates::{Crate, GitHubRepo};
-use experiments::Experiment;
-use log;
-use prelude::*;
-use results::{TestResult, WriteResults};
+use crate::agent::api::AgentApi;
+use crate::crates::{Crate, GitHubRepo};
+use crate::experiments::Experiment;
+use crate::log;
+use crate::prelude::*;
+use crate::results::{TestResult, WriteResults};
+use crate::toolchain::Toolchain;
 use std::io::Read;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
-use toolchain::Toolchain;
 
 #[derive(Clone)]
 pub struct ResultsUploader<'a> {

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,5 +1,5 @@
+use crate::prelude::*;
 use mime::{self, Mime};
-use prelude::*;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -11,8 +11,8 @@ lazy_static! {
     static ref TERA_CACHE: Tera = match build_tera_cache() {
         Ok(tera) => tera,
         Err(err) => {
-            ::utils::report_failure(&err);
-            ::std::process::exit(1);
+            crate::utils::report_failure(&err);
+            std::process::exit(1);
         }
     };
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ use crater::results::{DatabaseDB, DeleteResults};
 use crater::runner;
 use crater::server;
 use crater::toolchain::Toolchain;
-use failure::{Error, Fallible};
+use failure::{bail, Error, Fallible};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -61,7 +61,7 @@ impl FromStr for Dest {
     }
 }
 
-#[derive(StructOpt)]
+#[derive(structopt_derive::StructOpt)]
 #[structopt(
     name = "crater",
     about = "Kaboom!",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
-use crates::Crate;
-use prelude::*;
+use crate::crates::Crate;
+use crate::prelude::*;
+use crate::utils::size::Size;
 use regex::Regex;
 use serde_regex;
 use std::collections::{HashMap, HashSet};
@@ -8,7 +9,6 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
-use utils::size::Size;
 
 fn default_config_file() -> PathBuf {
     env::var_os("CRATER_CONFIG")
@@ -137,13 +137,13 @@ impl Config {
     }
 
     fn check_all(filename: PathBuf) -> Fallible<()> {
-        use experiments::CrateSelect;
+        use crate::experiments::CrateSelect;
 
         let buffer = Self::load_as_string(filename)?;
         let mut has_errors = Self::check_for_dup_keys(&buffer).is_err();
         let cfg: Self = ::toml::from_str(&buffer)?;
-        let db = ::db::Database::open()?;
-        let crates = ::crates::lists::get_crates(CrateSelect::Full, &db, &cfg)?;
+        let db = crate::db::Database::open()?;
+        let crates = crate::crates::lists::get_crates(CrateSelect::Full, &db, &cfg)?;
         has_errors |= cfg.check_for_missing_crates(&crates).is_err();
         has_errors |= cfg.check_for_missing_repos(&crates).is_err();
         if has_errors {
@@ -257,7 +257,7 @@ impl Default for Config {
 #[cfg(test)]
 mod tests {
     use super::Config;
-    use crates::{Crate, GitHubRepo, RegistryCrate};
+    use crate::crates::{Crate, GitHubRepo, RegistryCrate};
 
     #[test]
     fn test_config() {

--- a/src/crates/lists.rs
+++ b/src/crates/lists.rs
@@ -1,13 +1,15 @@
+use crate::config::Config;
+use crate::crates::{Crate, RegistryCrate};
+use crate::db::{Database, QueryUtils};
+use crate::experiments::CrateSelect;
+use crate::prelude::*;
 use chrono::Utc;
-use config::Config;
-use crates::{Crate, RegistryCrate};
-use db::{Database, QueryUtils};
-use experiments::CrateSelect;
-use prelude::*;
 use rand::{thread_rng, Rng};
 use std::collections::HashSet;
 
-pub(crate) use crates::sources::{github::GitHubList, local::LocalList, registry::RegistryList};
+pub(crate) use crate::crates::sources::{
+    github::GitHubList, local::LocalList, registry::RegistryList,
+};
 
 const SMALL_RANDOM_COUNT: usize = 20;
 
@@ -135,7 +137,7 @@ pub(crate) fn get_crates(
 
 #[cfg(test)]
 pub(crate) fn setup_test_lists(db: &Database, config: &Config) -> Fallible<()> {
-    ::actions::UpdateLists {
+    crate::actions::UpdateLists {
         github: false,
         registry: false,
         local: true,

--- a/src/crates/mod.rs
+++ b/src/crates/mod.rs
@@ -1,14 +1,14 @@
 pub(crate) mod lists;
 mod sources;
 
-use dirs::LOCAL_CRATES_DIR;
-use prelude::*;
+use crate::dirs::LOCAL_CRATES_DIR;
+use crate::prelude::*;
 use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 
-pub(crate) use crates::sources::github::GitHubRepo;
-pub(crate) use crates::sources::registry::RegistryCrate;
+pub(crate) use crate::crates::sources::github::GitHubRepo;
+pub(crate) use crate::crates::sources::registry::RegistryCrate;
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Clone)]
 pub enum Crate {
@@ -48,14 +48,14 @@ impl Crate {
                 "crate source directory {} already exists, cleaning it up",
                 dest.display()
             );
-            ::utils::fs::remove_dir_all(dest)?;
+            crate::utils::fs::remove_dir_all(dest)?;
         }
         match *self {
             Crate::Registry(ref details) => details.copy_to(&dest)?,
             Crate::GitHub(ref repo) => repo.copy_to(&dest)?,
             Crate::Local(ref name) => {
                 info!("copying local crate {} to {}", name, dest.display());
-                ::utils::fs::copy_dir(&LOCAL_CRATES_DIR.join(name), &dest)?;
+                crate::utils::fs::copy_dir(&LOCAL_CRATES_DIR.join(name), &dest)?;
             }
         }
 

--- a/src/crates/sources/github.rs
+++ b/src/crates/sources/github.rs
@@ -1,7 +1,7 @@
-use crates::{lists::List, Crate};
-use dirs::SOURCE_CACHE_DIR;
-use prelude::*;
-use run::RunCommand;
+use crate::crates::{lists::List, Crate};
+use crate::dirs::SOURCE_CACHE_DIR;
+use crate::prelude::*;
+use crate::run::RunCommand;
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -34,7 +34,7 @@ impl List for GitHubList {
     fn fetch(&self) -> Fallible<Vec<Crate>> {
         info!("loading cached GitHub list from {}", self.source);
 
-        let mut resp = ::utils::http::get_sync(&self.source)
+        let mut resp = crate::utils::http::get_sync(&self.source)
             .with_context(|_| format!("failed to fetch GitHub crates list from {}", self.source))?;
         let mut reader = ::csv::Reader::from_reader(&mut resp);
 
@@ -81,7 +81,7 @@ impl GitHubRepo {
         format!("{}/{}", self.org, self.name)
     }
 
-    pub(in crates) fn fetch(&self) -> Fallible<()> {
+    pub(in crate::crates) fn fetch(&self) -> Fallible<()> {
         let path = self.cached_path();
         if path.join("HEAD").is_file() {
             info!("updating cached repository {}", self.slug());
@@ -105,9 +105,9 @@ impl GitHubRepo {
         Ok(())
     }
 
-    pub(in crates) fn copy_to(&self, dest: &Path) -> Fallible<()> {
+    pub(in crate::crates) fn copy_to(&self, dest: &Path) -> Fallible<()> {
         if dest.exists() {
-            ::utils::fs::remove_dir_all(dest)?;
+            crate::utils::fs::remove_dir_all(dest)?;
         }
         RunCommand::new("git")
             .args(&["clone"])

--- a/src/crates/sources/local.rs
+++ b/src/crates/sources/local.rs
@@ -1,6 +1,6 @@
-use crates::{lists::List, Crate};
-use dirs::LOCAL_CRATES_DIR;
-use prelude::*;
+use crate::crates::{lists::List, Crate};
+use crate::dirs::LOCAL_CRATES_DIR;
+use crate::prelude::*;
 use std::path::PathBuf;
 
 pub(crate) struct LocalList {

--- a/src/crates/sources/mod.rs
+++ b/src/crates/sources/mod.rs
@@ -1,3 +1,3 @@
-pub(in crates) mod github;
-pub(in crates) mod local;
-pub(in crates) mod registry;
+pub(in crate::crates) mod github;
+pub(in crate::crates) mod local;
+pub(in crate::crates) mod registry;

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -1,4 +1,4 @@
-use prelude::*;
+use crate::prelude::*;
 use rand::{self, distributions::Alphanumeric, Rng};
 use rusqlite::{Connection, Transaction};
 use serde_json;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,7 +1,7 @@
 mod migrations;
 
-use dirs::WORK_DIR;
-use prelude::*;
+use crate::dirs::WORK_DIR;
+use crate::prelude::*;
 use r2d2::{CustomizeConnection, Pool};
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::types::ToSql;

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,9 +1,10 @@
-use crates::Crate;
-use experiments::Experiment;
+use crate::crates::Crate;
+use crate::experiments::Experiment;
+use crate::prelude::*;
+use crate::toolchain::Toolchain;
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;
-use toolchain::Toolchain;
 
 lazy_static! {
     pub static ref WORK_DIR: PathBuf = {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,10 +1,10 @@
-use prelude::*;
-use run::RunCommand;
+use crate::prelude::*;
+use crate::run::RunCommand;
+use crate::utils::size::Size;
 use std::env;
 use std::fmt::{self, Display, Formatter};
 use std::fs;
 use std::path::{Path, PathBuf};
-use utils::size::Size;
 
 pub(crate) fn is_running() -> bool {
     info!("checking if the docker daemon is running");
@@ -185,9 +185,11 @@ impl<'a> ContainerBuilder<'a> {
         let container = self.create()?;
 
         // Ensure the container is properly deleted even if something panics
-        defer! {{
-            if let Err(err) = container.delete().with_context(|_| format!("failed to delete container {}", container.id)) {
-                ::utils::report_failure(&err);
+        scopeguard::defer! {{
+            if let Err(err) = container.delete()
+                .with_context(|_| format!("failed to delete container {}", container.id))
+            {
+                crate::utils::report_failure(&err);
             }
         }}
 

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -1,12 +1,12 @@
+use crate::crates::Crate;
+use crate::db::{Database, QueryUtils};
+use crate::prelude::*;
+use crate::toolchain::Toolchain;
 use chrono::{DateTime, Utc};
-use crates::Crate;
-use db::{Database, QueryUtils};
-use prelude::*;
 use rusqlite::Row;
 use serde_json;
 use std::fmt;
 use std::str::FromStr;
-use toolchain::Toolchain;
 
 string_enum!(pub enum Status {
     Queued => "queued",
@@ -402,11 +402,11 @@ impl ExperimentDBRecord {
 #[cfg(test)]
 mod tests {
     use super::{Assignee, AssigneeParseError, Experiment, Status};
-    use actions::CreateExperiment;
-    use config::Config;
-    use db::Database;
-    use server::agents::Agents;
-    use server::tokens::Tokens;
+    use crate::actions::CreateExperiment;
+    use crate::config::Config;
+    use crate::db::Database;
+    use crate::server::agents::Agents;
+    use crate::server::tokens::Tokens;
     use std::str::FromStr;
 
     #[test]
@@ -442,7 +442,7 @@ mod tests {
         let db = Database::temp().unwrap();
         let config = Config::load().unwrap();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         let mut tokens = Tokens::default();
         tokens.agents.insert("token1".into(), "agent-1".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,65 +1,12 @@
 #![recursion_limit = "256"]
-#![deny(unused_extern_crates)]
 #![allow(clippy::needless_pass_by_value, clippy::new_ret_no_self)]
 
-extern crate base64;
-extern crate bytes;
-extern crate chrono;
-extern crate chrono_humanize;
-extern crate crates_index;
-extern crate crossbeam_utils;
-extern crate csv;
-#[macro_use]
-extern crate failure;
-extern crate flate2;
-extern crate futures;
-extern crate http;
-extern crate hyper;
-#[macro_use]
-extern crate lazy_static;
-extern crate mime;
-extern crate minifier;
-#[cfg(unix)]
-extern crate nix;
-#[macro_use]
-extern crate paste;
-extern crate petgraph;
-extern crate r2d2;
-extern crate r2d2_sqlite;
-extern crate rand;
-extern crate regex;
-extern crate reqwest;
-extern crate ring;
-extern crate rusoto_core;
-extern crate rusoto_credential;
-extern crate rusoto_s3;
-extern crate rusqlite;
-#[macro_use]
-extern crate scopeguard;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate serde_json;
-extern crate serde_regex;
 #[macro_use(slog_o, slog_info, slog_error, slog_warn)]
 extern crate slog;
 #[macro_use]
 extern crate slog_scope;
-extern crate slog_term;
-extern crate tar;
-extern crate tempfile;
-extern crate tera;
-extern crate tokio;
-extern crate tokio_process;
 #[cfg_attr(test, macro_use)]
 extern crate toml;
-#[macro_use]
-extern crate url;
-extern crate walkdir;
-extern crate warp;
-#[cfg(windows)]
-extern crate winapi;
 
 pub mod actions;
 pub mod agent;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,6 +1,6 @@
+use crate::dirs::LOG_DIR;
+use crate::prelude::*;
 use chrono::Utc;
-use dirs::LOG_DIR;
-use prelude::*;
 use slog::{self, Drain};
 use slog_scope;
 use slog_term;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,7 @@
-#![deny(unused_extern_crates)]
-extern crate dotenv;
 #[macro_use(slog_info)]
 extern crate slog;
 #[macro_use]
 extern crate slog_scope;
-extern crate structopt;
-#[macro_use]
-extern crate structopt_derive;
-#[macro_use]
-extern crate failure;
-
-extern crate crater;
 
 mod cli;
 

--- a/src/native/unix.rs
+++ b/src/native/unix.rs
@@ -1,8 +1,8 @@
+use crate::prelude::*;
 use nix::{
     sys::signal::{kill, Signal},
     unistd::{Gid, Pid, Uid},
 };
-use prelude::*;
 use std::convert::AsRef;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::Path;

--- a/src/native/windows.rs
+++ b/src/native/windows.rs
@@ -1,4 +1,4 @@
-use prelude::*;
+use crate::prelude::*;
 use std::path::Path;
 use winapi::um::handleapi::CloseHandle;
 use winapi::um::processthreadsapi::{OpenProcess, TerminateProcess};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,7 @@
 use failure::Context;
-pub use failure::{err_msg, Fail, Fallible, ResultExt};
+pub use failure::{bail, err_msg, Fail, Fallible, ResultExt};
+pub use lazy_static::lazy_static;
+pub use serde_derive::{Deserialize, Serialize};
 
 pub trait FailExt {
     fn downcast_ctx<T: Fail>(&self) -> Option<&T>;

--- a/src/report/archives.rs
+++ b/src/report/archives.rs
@@ -1,9 +1,9 @@
-use config::Config;
-use experiments::Experiment;
+use crate::config::Config;
+use crate::experiments::Experiment;
+use crate::prelude::*;
+use crate::report::{compare, ReportWriter};
+use crate::results::ReadResults;
 use flate2::{write::GzEncoder, Compression};
-use prelude::*;
-use report::{compare, ReportWriter};
-use results::ReadResults;
 use std::collections::HashMap;
 use tar::{Builder as TarBuilder, Header as TarHeader};
 
@@ -41,7 +41,7 @@ pub fn write_logs_archives<DB: ReadResults, W: ReportWriter>(
             let log_bytes: &[u8] = match log {
                 Ok(ref l) => l,
                 Err(e) => {
-                    ::utils::report_failure(&e);
+                    crate::utils::report_failure(&e);
                     continue;
                 }
             };
@@ -95,13 +95,13 @@ pub fn write_logs_archives<DB: ReadResults, W: ReportWriter>(
 #[cfg(test)]
 mod tests {
     use super::write_logs_archives;
-    use config::Config;
-    use db::Database;
-    use experiments::Experiment;
+    use crate::config::Config;
+    use crate::db::Database;
+    use crate::experiments::Experiment;
+    use crate::report::DummyWriter;
+    use crate::results::{DatabaseDB, FailureReason, TestResult, WriteResults};
     use flate2::read::GzDecoder;
     use mime::Mime;
-    use report::DummyWriter;
-    use results::{DatabaseDB, FailureReason, TestResult, WriteResults};
     use std::io::Read;
     use tar::Archive;
 
@@ -111,10 +111,10 @@ mod tests {
         let db = Database::temp().unwrap();
         let writer = DummyWriter::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // Create a dummy experiment
-        ::actions::CreateExperiment::dummy("dummy")
+        crate::actions::CreateExperiment::dummy("dummy")
             .apply(&db, &config)
             .unwrap();
         let ex = Experiment::get(&db, "dummy").unwrap().unwrap();

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -1,10 +1,10 @@
-use assets;
-use experiments::Experiment;
+use crate::assets;
+use crate::experiments::Experiment;
+use crate::prelude::*;
+use crate::report::{archives::Archive, Comparison, CrateResult, ReportWriter, TestResults};
+use crate::results::{FailureReason, TestResult};
 use mime;
 use minifier;
-use prelude::*;
-use report::{archives::Archive, Comparison, CrateResult, ReportWriter, TestResults};
-use results::{FailureReason, TestResult};
 use std::collections::HashMap;
 
 #[derive(Serialize)]
@@ -170,7 +170,7 @@ fn write_report<W: ReportWriter>(
                 .or_insert_with(|| run.res.name());
         }
 
-        let mut category = categories.entry(result.res).or_insert_with(Vec::new);
+        let category = categories.entry(result.res).or_insert_with(Vec::new);
         category.push(result.clone());
     }
 

--- a/src/report/s3.rs
+++ b/src/report/s3.rs
@@ -1,6 +1,6 @@
+use crate::prelude::*;
+use crate::report::ReportWriter;
 use mime::Mime;
-use prelude::*;
-use report::ReportWriter;
 use rusoto_core::request::HttpClient;
 use rusoto_core::{DefaultCredentialsProvider, Region};
 use rusoto_s3::{GetBucketLocationRequest, PutObjectRequest, S3Client, S3};

--- a/src/results/db.rs
+++ b/src/results/db.rs
@@ -1,13 +1,13 @@
+use crate::crates::{Crate, GitHubRepo};
+use crate::db::{Database, QueryUtils};
+use crate::experiments::Experiment;
+use crate::prelude::*;
+use crate::results::{DeleteResults, ReadResults, TestResult, WriteResults};
+use crate::toolchain::Toolchain;
 use base64;
-use crates::{Crate, GitHubRepo};
-use db::{Database, QueryUtils};
-use experiments::Experiment;
-use prelude::*;
-use results::{DeleteResults, ReadResults, TestResult, WriteResults};
 use serde_json;
 use std::collections::HashMap;
 use std::io::Read;
-use toolchain::Toolchain;
 
 #[derive(Deserialize)]
 pub struct TaskResult {
@@ -173,7 +173,7 @@ impl<'a> WriteResults for DatabaseDB<'a> {
         F: FnOnce() -> Fallible<TestResult>,
     {
         let mut log_file = ::tempfile::NamedTempFile::new()?;
-        let result = ::log::redirect(log_file.path(), f)?;
+        let result = crate::log::redirect(log_file.path(), f)?;
 
         let mut buffer = Vec::new();
         log_file.read_to_end(&mut buffer)?;
@@ -207,14 +207,14 @@ impl<'a> DeleteResults for DatabaseDB<'a> {
 #[cfg(test)]
 mod tests {
     use super::{DatabaseDB, ProgressData, TaskResult};
-    use actions::CreateExperiment;
+    use crate::actions::CreateExperiment;
+    use crate::config::Config;
+    use crate::crates::{Crate, GitHubRepo, RegistryCrate};
+    use crate::db::Database;
+    use crate::experiments::Experiment;
+    use crate::results::{DeleteResults, FailureReason, ReadResults, TestResult, WriteResults};
+    use crate::toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
     use base64;
-    use config::Config;
-    use crates::{Crate, GitHubRepo, RegistryCrate};
-    use db::Database;
-    use experiments::Experiment;
-    use results::{DeleteResults, FailureReason, ReadResults, TestResult, WriteResults};
-    use toolchain::{MAIN_TOOLCHAIN, TEST_TOOLCHAIN};
 
     #[test]
     fn test_shas() {
@@ -222,7 +222,7 @@ mod tests {
         let results = DatabaseDB::new(&db);
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // Create a dummy experiment to attach the results to
         CreateExperiment::dummy("dummy")
@@ -283,7 +283,7 @@ mod tests {
         let results = DatabaseDB::new(&db);
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // Create a dummy experiment to attach the results to
         CreateExperiment::dummy("dummy")
@@ -374,7 +374,7 @@ mod tests {
         let results = DatabaseDB::new(&db);
         let config = Config::default();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // Create a dummy experiment to attach the results to
         CreateExperiment::dummy("dummy")

--- a/src/results/dummy.rs
+++ b/src/results/dummy.rs
@@ -1,9 +1,9 @@
-use crates::{Crate, GitHubRepo};
-use experiments::Experiment;
-use prelude::*;
-use results::{ReadResults, TestResult};
+use crate::crates::{Crate, GitHubRepo};
+use crate::experiments::Experiment;
+use crate::prelude::*;
+use crate::results::{ReadResults, TestResult};
+use crate::toolchain::Toolchain;
 use std::collections::HashMap;
-use toolchain::Toolchain;
 
 #[derive(Default)]
 struct DummyData {

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -2,15 +2,15 @@ mod db;
 #[cfg(test)]
 mod dummy;
 
-use crates::{Crate, GitHubRepo};
-use experiments::Experiment;
-use prelude::*;
-pub use results::db::{DatabaseDB, ProgressData};
+use crate::crates::{Crate, GitHubRepo};
+use crate::experiments::Experiment;
+use crate::prelude::*;
+pub use crate::results::db::{DatabaseDB, ProgressData};
 #[cfg(test)]
-pub use results::dummy::DummyDB;
+pub use crate::results::dummy::DummyDB;
+use crate::toolchain::Toolchain;
 use std::collections::HashMap;
 use std::{fmt, str::FromStr};
-use toolchain::Toolchain;
 
 pub trait ReadResults {
     fn load_all_shas(&self, ex: &Experiment) -> Fallible<HashMap<GitHubRepo, String>>;

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -16,13 +16,13 @@
 //                                   |             |
 //                                   +---+ tc2 <---+
 
-use config::Config;
-use experiments::{Experiment, Mode};
+use crate::config::Config;
+use crate::experiments::{Experiment, Mode};
+use crate::prelude::*;
+use crate::results::{TestResult, WriteResults};
+use crate::runner::tasks::{Task, TaskStep};
 use failure::AsFail;
 use petgraph::{dot::Dot, graph::NodeIndex, stable_graph::StableDiGraph, Direction};
-use prelude::*;
-use results::{TestResult, WriteResults};
-use runner::tasks::{Task, TaskStep};
 use std::fmt::{self, Debug};
 use std::sync::Arc;
 

--- a/src/runner/prepare.rs
+++ b/src/runner/prepare.rs
@@ -1,15 +1,15 @@
-use config::Config;
-use crates::Crate;
-use dirs::crate_source_dir;
-use experiments::Experiment;
-use prelude::*;
-use results::{FailureReason, TestResult, WriteResults};
-use run::RunCommand;
-use runner::toml_frobber::TomlFrobber;
-use runner::OverrideResult;
+use crate::config::Config;
+use crate::crates::Crate;
+use crate::dirs::crate_source_dir;
+use crate::experiments::Experiment;
+use crate::prelude::*;
+use crate::results::{FailureReason, TestResult, WriteResults};
+use crate::run::RunCommand;
+use crate::runner::toml_frobber::TomlFrobber;
+use crate::runner::OverrideResult;
+use crate::toolchain::Toolchain;
+use crate::tools::CARGO;
 use std::path::PathBuf;
-use toolchain::Toolchain;
-use tools::CARGO;
 
 pub(super) struct PrepareCrate<'a, DB: WriteResults + 'a> {
     experiment: &'a Experiment,

--- a/src/runner/tasks.rs
+++ b/src/runner/tasks.rs
@@ -1,16 +1,16 @@
-use config::Config;
-use crates::Crate;
-use dirs;
-use docker::DockerEnv;
-use experiments::Experiment;
+use crate::config::Config;
+use crate::crates::Crate;
+use crate::dirs;
+use crate::docker::DockerEnv;
+use crate::experiments::Experiment;
+use crate::prelude::*;
+use crate::results::{TestResult, WriteResults};
+use crate::runner::prepare::PrepareCrate;
+use crate::runner::test;
+use crate::toolchain::Toolchain;
+use crate::utils;
 use failure::AsFail;
-use prelude::*;
-use results::{TestResult, WriteResults};
-use runner::prepare::PrepareCrate;
-use runner::test;
 use std::fmt;
-use toolchain::Toolchain;
-use utils;
 
 pub(super) struct TaskCtx<'ctx, DB: WriteResults + 'ctx> {
     pub(super) config: &'ctx Config,
@@ -187,7 +187,7 @@ impl Task {
                 test::run_test(
                     "checking unstable",
                     &ctx,
-                    ::runner::unstable_features::find_unstable_features,
+                    crate::runner::unstable_features::find_unstable_features,
                 )?;
             }
         }

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -1,11 +1,11 @@
-use docker::{DockerError, MountPerms};
+use crate::docker::{DockerError, MountPerms};
+use crate::prelude::*;
+use crate::results::{FailureReason, TestResult, WriteResults};
+use crate::run::{RunCommand, RunCommandError};
+use crate::runner::tasks::TaskCtx;
+use crate::tools::CARGO;
 use failure::Error;
-use prelude::*;
-use results::{FailureReason, TestResult, WriteResults};
-use run::{RunCommand, RunCommandError};
-use runner::tasks::TaskCtx;
 use std::path::Path;
-use tools::CARGO;
 
 fn failure_reason(err: &Error) -> FailureReason {
     for cause in err.iter_chain() {
@@ -69,7 +69,7 @@ pub(super) fn run_test<DB: WriteResults>(
     {
         info!("skipping crate {}. existing result: {}", ctx.krate, res);
     } else {
-        let source_path = ::dirs::crate_source_dir(ctx.experiment, ctx.toolchain, ctx.krate);
+        let source_path = crate::dirs::crate_source_dir(ctx.experiment, ctx.toolchain, ctx.krate);
         ctx.db
             .record_result(ctx.experiment, ctx.toolchain, ctx.krate, || {
                 info!(
@@ -153,7 +153,7 @@ pub(super) fn test_rustdoc<DB: WriteResults>(
     // Make sure to remove the built documentation
     // There is no point in storing it after the build is done
     let target_dir = ctx.toolchain.target_dir(&ctx.experiment.name);
-    ::utils::fs::remove_dir_all(&target_dir.join("doc"))?;
+    crate::utils::fs::remove_dir_all(&target_dir.join("doc"))?;
 
     if let Err(err) = res {
         Ok(TestResult::BuildFail(failure_reason(&err)))

--- a/src/runner/toml_frobber.rs
+++ b/src/runner/toml_frobber.rs
@@ -1,5 +1,5 @@
-use crates::Crate;
-use prelude::*;
+use crate::crates::Crate;
+use crate::prelude::*;
 use std::path::Path;
 use toml::value::Table;
 use toml::{self, Value};
@@ -135,8 +135,8 @@ impl<'a> TomlFrobber<'a> {
 #[cfg(test)]
 mod tests {
     use super::TomlFrobber;
-    use crates::Crate;
-    use toml::Value;
+    use crate::crates::Crate;
+    use toml::{self, Value};
 
     #[test]
     fn test_frob_table_noop() {

--- a/src/runner/unstable_features.rs
+++ b/src/runner/unstable_features.rs
@@ -1,7 +1,7 @@
-use prelude::*;
-use results::TestResult;
-use results::WriteResults;
-use runner::tasks::TaskCtx;
+use crate::prelude::*;
+use crate::results::TestResult;
+use crate::results::WriteResults;
+use crate::runner::tasks::TaskCtx;
 use std::collections::HashSet;
 use std::path::Path;
 use walkdir::{DirEntry, WalkDir};

--- a/src/server/agents.rs
+++ b/src/server/agents.rs
@@ -1,9 +1,9 @@
+use crate::db::{Database, QueryUtils};
+use crate::experiments::{Assignee, Experiment};
+use crate::prelude::*;
+use crate::server::tokens::Tokens;
 use chrono::Duration;
 use chrono::{DateTime, Utc};
-use db::{Database, QueryUtils};
-use experiments::{Assignee, Experiment};
-use prelude::*;
-use server::tokens::Tokens;
 use std::collections::HashSet;
 
 /// Number of seconds without an heartbeat after an agent should be considered unreachable.
@@ -151,11 +151,11 @@ impl Agents {
 #[cfg(test)]
 mod tests {
     use super::{AgentStatus, Agents};
-    use actions::CreateExperiment;
-    use config::Config;
-    use db::Database;
-    use experiments::{Assignee, Experiment};
-    use server::tokens::Tokens;
+    use crate::actions::CreateExperiment;
+    use crate::config::Config;
+    use crate::db::Database;
+    use crate::experiments::{Assignee, Experiment};
+    use crate::server::tokens::Tokens;
 
     #[test]
     fn test_agents_synchronize() {
@@ -221,7 +221,7 @@ mod tests {
         tokens.agents.insert("token".into(), "agent".into());
         let agents = Agents::new(db.clone(), &tokens).unwrap();
 
-        ::crates::lists::setup_test_lists(&db, &config).unwrap();
+        crate::crates::lists::setup_test_lists(&db, &config).unwrap();
 
         // When no heartbeat is recorded, the agent is unreachable
         let agent = agents.get("agent").unwrap().unwrap();

--- a/src/server/api_types.rs
+++ b/src/server/api_types.rs
@@ -1,9 +1,9 @@
-use config::Config;
+use crate::config::Config;
+use crate::prelude::*;
 use http::header::{HeaderValue, CONTENT_TYPE};
 use http::Response;
 use http::StatusCode;
 use hyper::Body;
-use prelude::*;
 use serde::Serialize;
 use std::fmt;
 use std::fmt::Display;
@@ -26,15 +26,15 @@ pub enum ApiResponse<T> {
 }
 
 impl ApiResponse<()> {
-    pub(in server) fn internal_error(error: String) -> ApiResponse<()> {
+    pub(in crate::server) fn internal_error(error: String) -> ApiResponse<()> {
         ApiResponse::InternalError { error }
     }
 
-    pub(in server) fn unauthorized() -> ApiResponse<()> {
+    pub(in crate::server) fn unauthorized() -> ApiResponse<()> {
         ApiResponse::Unauthorized
     }
 
-    pub(in server) fn not_found() -> ApiResponse<()> {
+    pub(in crate::server) fn not_found() -> ApiResponse<()> {
         ApiResponse::NotFound
     }
 }
@@ -51,7 +51,7 @@ impl<T> ApiResponse<T> {
 }
 
 impl<T: Serialize> ApiResponse<T> {
-    pub(in server) fn into_response(self) -> Fallible<Response<Body>> {
+    pub(in crate::server) fn into_response(self) -> Fallible<Response<Body>> {
         let serialized = ::serde_json::to_vec(&self)?;
 
         let mut resp = Response::new(serialized.into());

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,9 +1,9 @@
-use config::Config;
+use crate::config::Config;
+use crate::prelude::*;
+use crate::server::github::GitHubApi;
+use crate::server::{Data, HttpError};
 use http::header::{HeaderMap, AUTHORIZATION, USER_AGENT};
-use prelude::*;
 use regex::Regex;
-use server::github::GitHubApi;
-use server::{Data, HttpError};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use warp::{self, Filter, Rejection};

--- a/src/server/github.rs
+++ b/src/server/github.rs
@@ -1,11 +1,12 @@
+use crate::prelude::*;
+use crate::server::tokens::Tokens;
+use crate::utils;
 use http::header::AUTHORIZATION;
 use http::Method;
 use http::StatusCode;
-use prelude::*;
 use reqwest::RequestBuilder;
-use server::tokens::Tokens;
+use serde_json::json;
 use std::collections::HashMap;
-use utils::http;
 
 #[derive(Debug, Fail)]
 pub enum GitHubError {
@@ -32,7 +33,8 @@ impl GitHubApi {
             url.to_string()
         };
 
-        http::prepare_sync(method, &url).header(AUTHORIZATION, format!("token {}", self.token))
+        utils::http::prepare_sync(method, &url)
+            .header(AUTHORIZATION, format!("token {}", self.token))
     }
 
     pub fn username(&self) -> Fallible<String> {

--- a/src/server/messages.rs
+++ b/src/server/messages.rs
@@ -1,5 +1,5 @@
-use prelude::*;
-use server::Data;
+use crate::prelude::*;
+use crate::server::Data;
 
 pub enum Label {
     ExperimentQueued,
@@ -54,7 +54,7 @@ impl Message {
             format!(
                 "**Crater** is a tool to run experiments across parts of the Rust ecosystem. \
                  [Learn more]({})",
-                ::CRATER_REPO_URL,
+                crate::CRATER_REPO_URL,
             ),
         );
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,20 +7,21 @@ mod reports;
 mod routes;
 pub mod tokens;
 
-use config::Config;
-use db::Database;
+use crate::config::Config;
+use crate::db::Database;
+use crate::prelude::*;
+use crate::server::agents::Agents;
+use crate::server::auth::ACL;
+use crate::server::github::GitHubApi;
+use crate::server::tokens::Tokens;
 use http::{self, header::HeaderValue, Response};
 use hyper::Body;
-use prelude::*;
-use server::agents::Agents;
-use server::auth::ACL;
-use server::github::GitHubApi;
-use server::tokens::Tokens;
 use std::sync::Arc;
 use warp::{self, Filter};
 
 lazy_static! {
-    static ref SERVER_HEADER: String = format!("crater/{}", ::GIT_REVISION.unwrap_or("unknown"));
+    static ref SERVER_HEADER: String =
+        format!("crater/{}", crate::GIT_REVISION.unwrap_or("unknown"));
 }
 
 #[derive(Debug, Fail, PartialEq, Eq, Copy, Clone)]

--- a/src/server/reports.rs
+++ b/src/server/reports.rs
@@ -1,15 +1,15 @@
-use experiments::{Experiment, Status};
-use prelude::*;
-use report::{self, Comparison, TestResults};
-use results::DatabaseDB;
+use crate::experiments::{Experiment, Status};
+use crate::prelude::*;
+use crate::report::{self, Comparison, TestResults};
+use crate::results::DatabaseDB;
+use crate::server::messages::{Label, Message};
+use crate::server::Data;
+use crate::utils;
 use rusoto_core::request::HttpClient;
 use rusoto_s3::S3Client;
-use server::messages::{Label, Message};
-use server::Data;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 use std::time::Duration;
-use utils;
 
 // Automatically wake up the reports generator thread every 10 minutes to check for new jobs
 const AUTOMATIC_THREAD_WAKEUP: u64 = 600;
@@ -116,7 +116,7 @@ fn reports_thread(data: &Data, wakes: &mpsc::Receiver<()>) -> Fallible<()> {
                             format!(
                                 "If you notice any spurious failure [please add them to the \
                                  blacklist]({}/blob/master/config.toml)!",
-                                ::CRATER_REPO_URL,
+                                crate::CRATER_REPO_URL,
                             ),
                         )
                         .set_label(Label::ExperimentCompleted)

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -1,13 +1,13 @@
-use experiments::{Assignee, Experiment, Status};
+use crate::experiments::{Assignee, Experiment, Status};
+use crate::prelude::*;
+use crate::results::{DatabaseDB, ProgressData};
+use crate::server::api_types::{AgentConfig, ApiResponse};
+use crate::server::auth::{auth_filter, AuthDetails, TokenType};
+use crate::server::messages::Message;
+use crate::server::{Data, HttpError};
 use failure::Compat;
 use http::{Response, StatusCode};
 use hyper::Body;
-use prelude::*;
-use results::{DatabaseDB, ProgressData};
-use server::api_types::{AgentConfig, ApiResponse};
-use server::auth::{auth_filter, AuthDetails, TokenType};
-use server::messages::Message;
-use server::{Data, HttpError};
 use std::sync::Arc;
 use warp::{self, Filter, Rejection};
 

--- a/src/server/routes/ui/agents.rs
+++ b/src/server/routes/ui/agents.rs
@@ -1,10 +1,10 @@
+use crate::prelude::*;
+use crate::server::agents::AgentStatus;
+use crate::server::routes::ui::{render_template, LayoutContext};
+use crate::server::Data;
 use chrono::SecondsFormat;
 use http::Response;
 use hyper::Body;
-use prelude::*;
-use server::agents::AgentStatus;
-use server::routes::ui::{render_template, LayoutContext};
-use server::Data;
 use std::sync::Arc;
 
 #[derive(Serialize)]

--- a/src/server/routes/ui/experiments.rs
+++ b/src/server/routes/ui/experiments.rs
@@ -1,11 +1,11 @@
+use crate::experiments::{Experiment, Mode, Status};
+use crate::prelude::*;
+use crate::server::routes::ui::{render_template, LayoutContext};
+use crate::server::{Data, HttpError};
 use chrono::{Duration, SecondsFormat, Utc};
 use chrono_humanize::{Accuracy, HumanTime, Tense};
-use experiments::{Experiment, Mode, Status};
 use http::Response;
 use hyper::Body;
-use prelude::*;
-use server::routes::ui::{render_template, LayoutContext};
-use server::{Data, HttpError};
 use std::sync::Arc;
 
 #[derive(Serialize)]

--- a/src/server/routes/ui/mod.rs
+++ b/src/server/routes/ui/mod.rs
@@ -1,10 +1,10 @@
-use assets;
+use crate::assets;
+use crate::prelude::*;
+use crate::server::{Data, HttpError};
 use http::header::{HeaderValue, CONTENT_TYPE};
 use http::{Response, StatusCode};
 use hyper::Body;
-use prelude::*;
 use serde::Serialize;
-use server::{Data, HttpError};
 use std::sync::Arc;
 use warp::{self, Filter, Rejection};
 
@@ -19,7 +19,7 @@ struct LayoutContext {
 impl LayoutContext {
     fn new() -> Self {
         LayoutContext {
-            git_revision: ::GIT_REVISION,
+            git_revision: crate::GIT_REVISION,
         }
     }
 }
@@ -111,7 +111,7 @@ fn error_500() -> Response<Body> {
         Ok(resp) => resp,
         Err(err) => {
             error!("failed to render 500 error page!");
-            ::utils::report_failure(&err);
+            crate::utils::report_failure(&err);
             Response::new("500: Internal Server Error\n".into())
         }
     };
@@ -132,13 +132,13 @@ fn handle_results(resp: Fallible<Response<Body>>) -> Response<Body> {
                 match error_404() {
                     Ok(content) => return content,
                     Err(err404) => {
-                        ::utils::report_failure(&err404);
+                        crate::utils::report_failure(&err404);
                         return error_500();
                     }
                 }
             }
 
-            ::utils::report_failure(&err);
+            crate::utils::report_failure(&err);
             error_500()
         }
     }
@@ -150,7 +150,7 @@ fn handle_errors(err: Rejection) -> Result<Response<Body>, Rejection> {
             Ok(resp) => Ok(resp),
             Err(err) => {
                 error!("failed to render 404 page!");
-                ::utils::report_failure(&err);
+                crate::utils::report_failure(&err);
                 Ok(error_500())
             }
         },

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -1,5 +1,5 @@
-use experiments::{CapLints, CrateSelect, Mode};
-use toolchain::Toolchain;
+use crate::experiments::{CapLints, CrateSelect, Mode};
+use crate::toolchain::Toolchain;
 
 #[derive(Debug, Fail)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
@@ -21,9 +21,9 @@ macro_rules! generate_parser {
         }))*
         _ => $d_variant:ident($d_var_struct:ident {$($d_flag:ident: $d_type:ty = $d_name:expr,)*})
     }) => {
-        use prelude::*;
+        use crate::prelude::*;
         use std::str::FromStr;
-        use utils::string::split_quoted;
+        use crate::utils::string::split_quoted;
 
         $(
             #[cfg_attr(test, derive(Debug, PartialEq))]
@@ -43,7 +43,7 @@ macro_rules! generate_parser {
             $($variant($var_struct),)*
         }
 
-        #[allow(unused_variables)]
+        #[allow(unused_variables, unused_mut)]
         impl FromStr for $enum {
             type Err = ::failure::Error;
 

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -1,10 +1,10 @@
-use db::{Database, QueryUtils};
-use experiments::{CapLints, CrateSelect, Experiment, GitHubIssue, Mode, Status};
-use prelude::*;
-use server::github::Issue;
-use server::messages::{Label, Message};
-use server::routes::webhooks::args::{AbortArgs, EditArgs, RetryReportArgs, RunArgs};
-use server::Data;
+use crate::db::{Database, QueryUtils};
+use crate::experiments::{CapLints, CrateSelect, Experiment, GitHubIssue, Mode, Status};
+use crate::prelude::*;
+use crate::server::github::Issue;
+use crate::server::messages::{Label, Message};
+use crate::server::routes::webhooks::args::{AbortArgs, EditArgs, RetryReportArgs, RunArgs};
+use crate::server::Data;
 
 pub fn ping(data: &Data, issue: &Issue) -> Fallible<()> {
     Message::new()
@@ -17,7 +17,7 @@ pub fn ping(data: &Data, issue: &Issue) -> Fallible<()> {
 pub fn run(host: &str, data: &Data, issue: &Issue, args: RunArgs) -> Fallible<()> {
     let name = setup_run_name(&data.db, issue, args.name)?;
 
-    ::actions::CreateExperiment {
+    crate::actions::CreateExperiment {
         name: name.clone(),
         toolchains: [
             args.start
@@ -57,7 +57,7 @@ pub fn run(host: &str, data: &Data, issue: &Issue, args: RunArgs) -> Fallible<()
 pub fn edit(data: &Data, issue: &Issue, args: EditArgs) -> Fallible<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
-    let changed = ::actions::EditExperiment {
+    let changed = crate::actions::EditExperiment {
         name: name.clone(),
         toolchains: [args.start, args.end],
         crates: args.crates,
@@ -114,7 +114,7 @@ pub fn retry_report(data: &Data, issue: &Issue, args: RetryReportArgs) -> Fallib
 pub fn abort(data: &Data, issue: &Issue, args: AbortArgs) -> Fallible<()> {
     let name = get_name(&data.db, issue, args.name)?;
 
-    ::actions::DeleteExperiment { name: name.clone() }.apply(&data.db, &data.config)?;
+    crate::actions::DeleteExperiment { name: name.clone() }.apply(&data.db, &data.config)?;
 
     Message::new()
         .line("wastebasket", format!("Experiment **`{}`** deleted!", name))
@@ -205,21 +205,23 @@ mod tests {
         default_experiment_name, generate_new_experiment_name, get_name, setup_run_name,
         store_experiment_name,
     };
-    use db::Database;
-    use prelude::*;
-    use server::github;
+    use crate::db::Database;
+    use crate::prelude::*;
+    use crate::server::github;
 
     /// Simulate to the `run` command, and return experiment name
     fn dummy_run(db: &Database, issue: &github::Issue, name: Option<String>) -> Fallible<String> {
         let name = setup_run_name(db, issue, name)?;
-        ::actions::CreateExperiment::dummy(&name).apply(&db, &::config::Config::default())?;
+        crate::actions::CreateExperiment::dummy(&name)
+            .apply(&db, &crate::config::Config::default())?;
         Ok(name)
     }
 
     /// Simulate to the `edit` command, and return experiment name
     fn dummy_edit(db: &Database, issue: &github::Issue, name: Option<String>) -> Fallible<String> {
         let name = get_name(db, issue, name)?;
-        ::actions::EditExperiment::dummy(&name).apply(&db, &::config::Config::default())?;
+        crate::actions::EditExperiment::dummy(&name)
+            .apply(&db, &crate::config::Config::default())?;
         Ok(name)
     }
 
@@ -387,13 +389,13 @@ mod tests {
             }),
         };
 
-        ::actions::CreateExperiment::dummy("pr-12345")
-            .apply(&db, &::config::Config::default())
+        crate::actions::CreateExperiment::dummy("pr-12345")
+            .apply(&db, &crate::config::Config::default())
             .expect("could not store dummy experiment");
         let new_name = generate_new_experiment_name(&db, &pr).unwrap();
         assert_eq!(new_name, "pr-12345-1");
-        ::actions::CreateExperiment::dummy("pr-12345-1")
-            .apply(&db, &::config::Config::default())
+        crate::actions::CreateExperiment::dummy("pr-12345-1")
+            .apply(&db, &crate::config::Config::default())
             .expect("could not store dummy experiment");;
         assert_eq!(
             &generate_new_experiment_name(&db, &pr).unwrap(),

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -1,16 +1,16 @@
 mod args;
 mod commands;
 
+use crate::prelude::*;
+use crate::server::github::{EventIssueComment, Issue};
+use crate::server::messages::Message;
+use crate::server::routes::webhooks::args::Command;
+use crate::server::Data;
 use bytes::buf::Buf;
 use http::{HeaderMap, Response, StatusCode};
 use hyper::Body;
-use prelude::*;
 use ring;
 use serde_json;
-use server::github::{EventIssueComment, Issue};
-use server::messages::Message;
-use server::routes::webhooks::args::Command;
-use server::Data;
 use std::str::FromStr;
 use std::sync::Arc;
 use warp::{self, filters::body::FullBody, Filter, Rejection};
@@ -82,7 +82,7 @@ fn process_command(
                     format!(
                         "If you are a member of the Rust team and need access, [add yourself to \
                          the whitelist]({}/blob/master/config.toml).",
-                        ::CRATER_REPO_URL,
+                        crate::CRATER_REPO_URL,
                     ),
                 )
                 .send(&issue.url, data)?;
@@ -143,7 +143,7 @@ fn verify_signature(secret: &str, payload: &[u8], raw_signature: &str) -> bool {
         .join("=");
 
     // Convert the signature from hex
-    let signature = if let Ok(converted) = ::utils::hex::from_hex(&hex_signature) {
+    let signature = if let Ok(converted) = crate::utils::hex::from_hex(&hex_signature) {
         converted
     } else {
         // This is not hex
@@ -197,7 +197,7 @@ pub fn routes(
                 Ok(()) => resp = Response::new("OK\n".into()),
                 Err(err) => {
                     error!("error while processing webhook");
-                    ::utils::report_failure(&err);
+                    crate::utils::report_failure(&err);
 
                     resp = Response::new(format!("Error: {}\n", err).into());
                     *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;

--- a/src/server/tokens.rs
+++ b/src/server/tokens.rs
@@ -1,6 +1,7 @@
-use prelude::*;
+use crate::prelude::*;
 use rusoto_core::Region;
 use rusoto_credential::StaticProvider;
+use serde_derive::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -1,13 +1,13 @@
-use dirs::TARGET_DIR;
-use prelude::*;
-use run::RunCommand;
+use crate::dirs::TARGET_DIR;
+use crate::prelude::*;
+use crate::run::RunCommand;
+use crate::tools::CARGO;
+use crate::tools::{RUSTUP, RUSTUP_TOOLCHAIN_INSTALL_MASTER};
+use crate::utils;
 use std::borrow::Cow;
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
-use tools::CARGO;
-use tools::{RUSTUP, RUSTUP_TOOLCHAIN_INSTALL_MASTER};
-use utils;
 
 pub(crate) static MAIN_TOOLCHAIN_NAME: &str = "stable";
 
@@ -42,7 +42,7 @@ pub enum ToolchainSource {
     #[serde(rename = "ci")]
     CI {
         sha: Cow<'static, str>,
-        try: bool,
+        r#try: bool,
     },
 }
 
@@ -106,8 +106,8 @@ impl fmt::Display for Toolchain {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.source {
             ToolchainSource::Dist { ref name } => write!(f, "{}", name)?,
-            ToolchainSource::CI { ref sha, try } => {
-                if try {
+            ToolchainSource::CI { ref sha, r#try } => {
+                if r#try {
                     write!(f, "try#{}", sha)?;
                 } else {
                     write!(f, "master#{}", sha)?;
@@ -151,11 +151,11 @@ impl FromStr for Toolchain {
             match source_name {
                 "try" => ToolchainSource::CI {
                     sha: Cow::Owned(sha),
-                    try: true,
+                    r#try: true,
                 },
                 "master" => ToolchainSource::CI {
                     sha: Cow::Owned(sha),
-                    try: false,
+                    r#try: false,
                 },
                 name => return Err(ToolchainParseError::InvalidSourceName(name.to_string())),
             }
@@ -277,11 +277,11 @@ mod tests {
             },
             "master#0000000000000000000000000000000000000000" => ToolchainSource::CI {
                 sha: "0000000000000000000000000000000000000000".into(),
-                try: false,
+                r#try: false,
             },
             "try#0000000000000000000000000000000000000000" => ToolchainSource::CI {
                 sha: "0000000000000000000000000000000000000000".into(),
-                try: true,
+                r#try: true,
             },
         };
 

--- a/src/tools/binary_crates.rs
+++ b/src/tools/binary_crates.rs
@@ -1,12 +1,12 @@
-use native;
-use prelude::*;
-use run::{Binary, RunCommand, Runnable};
-use tools::{binary_path, InstallableTool, CARGO, CARGO_INSTALL_UPDATE};
+use crate::native;
+use crate::prelude::*;
+use crate::run::{Binary, RunCommand, Runnable};
+use crate::tools::{binary_path, InstallableTool, CARGO, CARGO_INSTALL_UPDATE};
 
 pub(crate) struct BinaryCrate {
-    pub(in tools) crate_name: &'static str,
-    pub(in tools) binary: &'static str,
-    pub(in tools) cargo_subcommand: Option<&'static str>,
+    pub(in crate::tools) crate_name: &'static str,
+    pub(in crate::tools) binary: &'static str,
+    pub(in crate::tools) cargo_subcommand: Option<&'static str>,
 }
 
 impl Runnable for BinaryCrate {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,13 +1,13 @@
 mod binary_crates;
 mod rustup;
 
-use dirs::CARGO_HOME;
-use prelude::*;
+use crate::dirs::CARGO_HOME;
+use crate::prelude::*;
+use crate::toolchain::MAIN_TOOLCHAIN;
+use crate::tools::binary_crates::BinaryCrate;
+use crate::tools::rustup::{Cargo, Rustup};
 use std::env::consts::EXE_SUFFIX;
 use std::path::PathBuf;
-use toolchain::MAIN_TOOLCHAIN;
-use tools::binary_crates::BinaryCrate;
-use tools::rustup::{Cargo, Rustup};
 
 pub(crate) static RUSTUP: Rustup = Rustup;
 

--- a/src/tools/rustup.rs
+++ b/src/tools/rustup.rs
@@ -1,14 +1,14 @@
-use dirs::{CARGO_HOME, RUSTUP_HOME};
-use native;
-use prelude::*;
-use run::{Binary, RunCommand, Runnable};
+use crate::dirs::{CARGO_HOME, RUSTUP_HOME};
+use crate::native;
+use crate::prelude::*;
+use crate::run::{Binary, RunCommand, Runnable};
+use crate::toolchain::Toolchain;
+use crate::toolchain::MAIN_TOOLCHAIN_NAME;
+use crate::tools::{binary_path, InstallableTool, RUSTUP};
 use std::env::consts::EXE_SUFFIX;
 use std::fs::{self, File};
 use std::io;
 use tempfile::tempdir;
-use toolchain::Toolchain;
-use toolchain::MAIN_TOOLCHAIN_NAME;
-use tools::{binary_path, InstallableTool, RUSTUP};
 
 static RUSTUP_BASE_URL: &str = "https://static.rust-lang.org/rustup/dist";
 
@@ -45,11 +45,11 @@ impl InstallableTool for Rustup {
         let url = format!(
             "{}/{}/rustup-init{}",
             RUSTUP_BASE_URL,
-            ::HOST_TARGET,
+            crate::HOST_TARGET,
             EXE_SUFFIX
         );
         let mut resp =
-            ::utils::http::get_sync(&url).with_context(|_| "unable to download rustup")?;
+            crate::utils::http::get_sync(&url).with_context(|_| "unable to download rustup")?;
 
         let tempdir = tempdir()?;
         let installer = &tempdir.path().join(format!("rustup-init{}", EXE_SUFFIX));
@@ -87,8 +87,8 @@ impl InstallableTool for Rustup {
 }
 
 pub(crate) struct Cargo<'a> {
-    pub(in tools) toolchain: &'a Toolchain,
-    pub(in tools) unstable_features: bool,
+    pub(in crate::tools) toolchain: &'a Toolchain,
+    pub(in crate::tools) unstable_features: bool,
 }
 
 impl<'a> Cargo<'a> {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,7 +1,7 @@
-use prelude::*;
+use crate::prelude::*;
+use crate::utils::try_hard_limit;
 use std::fs;
 use std::path::{Path, PathBuf};
-use utils::try_hard_limit;
 use walkdir::{DirEntry, WalkDir};
 
 pub(crate) fn try_canonicalize<P: AsRef<Path>>(path: P) -> PathBuf {

--- a/src/utils/hex.rs
+++ b/src/utils/hex.rs
@@ -1,4 +1,4 @@
-use prelude::*;
+use crate::prelude::*;
 
 #[derive(Debug, Fail)]
 #[cfg_attr(test, derive(PartialEq, Eq))]

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -1,5 +1,5 @@
+use crate::prelude::*;
 use http::{header::USER_AGENT, Method, StatusCode};
-use prelude::*;
 use reqwest::{Client, ClientBuilder, RedirectPolicy, RequestBuilder, Response};
 
 const MAX_REDIRECTS: usize = 4;
@@ -15,8 +15,8 @@ lazy_static! {
     static ref HTTP_SYNC_CLIENT: Client = setup_sync_client();
     static ref USER_AGENT_CONTENT: String = format!(
         "crater/{} ({})",
-        ::GIT_REVISION.unwrap_or("unknown"),
-        ::CRATER_REPO_URL
+        crate::GIT_REVISION.unwrap_or("unknown"),
+        crate::CRATER_REPO_URL
     );
 }
 

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -42,7 +42,7 @@ macro_rules! string_enum {
 
 macro_rules! impl_serde_from_parse {
     ($for:ident, expecting=$expecting:expr) => {
-        item! {
+        paste::item! {
             struct [<$for Visitor>];
 
             impl<'de> ::serde::de::Visitor<'de> for [<$for Visitor>] {
@@ -64,7 +64,7 @@ macro_rules! impl_serde_from_parse {
             where
                 D: ::serde::de::Deserializer<'de>,
             {
-                deserializer.deserialize_str(expr! { [<$for Visitor>] })
+                deserializer.deserialize_str(paste::expr! { [<$for Visitor>] })
             }
         }
 

--- a/src/utils/size.rs
+++ b/src/utils/size.rs
@@ -1,4 +1,4 @@
-use prelude::*;
+use crate::prelude::*;
 use std::fmt;
 use std::str::FromStr;
 

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,4 +1,4 @@
-use prelude::*;
+use crate::prelude::*;
 
 #[derive(Debug, Fail)]
 pub enum SplitQuotedError {

--- a/tests/check_config/mod.rs
+++ b/tests/check_config/mod.rs
@@ -1,5 +1,5 @@
+use crate::common::CommandCraterExt;
 use assert_cmd::prelude::*;
-use common::CommandCraterExt;
 use predicates::str::contains;
 use std::process::Command;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,12 +1,3 @@
-extern crate assert_cmd;
-extern crate difference;
-extern crate num_cpus;
-extern crate predicates;
-extern crate rand;
-extern crate serde;
-extern crate serde_json;
-extern crate tempfile;
-
 mod check_config;
 mod common;
 mod minicrater;

--- a/tests/minicrater/mod.rs
+++ b/tests/minicrater/mod.rs
@@ -1,5 +1,5 @@
+use crate::common::CommandCraterExt;
 use assert_cmd::prelude::*;
-use common::CommandCraterExt;
 use difference::Changeset;
 use rand::{self, distributions::Alphanumeric, Rng};
 use serde_json::{self, Value};


### PR DESCRIPTION
This PR migrates Crater to Rust 2018. Mostly `cargo fix`, `cargo fmt` and a little manual fixing inside macros and `#[macro_use]`.