### PR TITLE
Restrict the amount of content allowed in build logs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,6 +29,9 @@ local-crates = []
 [sandbox]
 # Maximum amount of RAM allowed during builds
 memory-limit = "1536M"  # 1.5G
+# Restrictions on the amount of information stored in build logs
+build-log-max-size = "5M"
+build-log-max-lines = 10000
 
 
 # These sections allows to customize how crater treats specific crates/repos

--- a/src/agent/results.rs
+++ b/src/agent/results.rs
@@ -1,4 +1,5 @@
 use crate::agent::api::AgentApi;
+use crate::config::Config;
 use crate::crates::{Crate, GitHubRepo};
 use crate::experiments::Experiment;
 use crate::logs::{self, LogStorage};
@@ -49,12 +50,13 @@ impl<'a> WriteResults for ResultsUploader<'a> {
         toolchain: &Toolchain,
         krate: &Crate,
         existing_logs: Option<LogStorage>,
+        config: &Config,
         f: F,
     ) -> Fallible<TestResult>
     where
         F: FnOnce() -> Fallible<TestResult>,
     {
-        let storage = existing_logs.unwrap_or_else(|| LogStorage::new(LevelFilter::Info));
+        let storage = existing_logs.unwrap_or_else(|| LogStorage::new(LevelFilter::Info, config));
         let result = logs::capture(&storage, f)?;
         let output = storage.to_string();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,8 @@ pub struct DemoCrates {
 #[serde(rename_all = "kebab-case")]
 pub struct SandboxConfig {
     pub memory_limit: Size,
+    pub build_log_max_size: Size,
+    pub build_log_max_lines: usize,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -241,6 +243,8 @@ impl Default for Config {
             local_crates: HashMap::new(),
             sandbox: SandboxConfig {
                 memory_limit: Size::Gigabytes(2),
+                build_log_max_size: Size::Megabytes(1),
+                build_log_max_lines: 1000,
             },
             server: ServerConfig {
                 bot_acl: Vec::new(),
@@ -275,6 +279,8 @@ mod tests {
             "local-crates = []\n",
             "[sandbox]\n",
             "memory-limit = \"2G\"\n",
+            "build-log-max-size = \"2M\"\n",
+            "build-log-max-lines = 1000\n",
             "[crates]\n",
             "lazy_static = { skip = true }\n",
             "[github-repos]\n",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![recursion_limit = "256"]
-#![allow(clippy::needless_pass_by_value, clippy::new_ret_no_self)]
+#![allow(
+    clippy::needless_pass_by_value,
+    clippy::new_ret_no_self,
+    clippy::too_many_arguments
+)]
 
 #[cfg_attr(test, macro_use)]
 extern crate toml;

--- a/src/logs/mod.rs
+++ b/src/logs/mod.rs
@@ -1,6 +1,5 @@
 mod storage;
 
-use crate::prelude::*;
 use log::{Log, Metadata, Record};
 use std::cell::RefCell;
 use std::sync::Once;
@@ -60,9 +59,9 @@ impl Log for MultiLogger {
     }
 }
 
-pub fn capture<F, R, L>(storage: &L, f: F) -> Fallible<R>
+pub fn capture<F, R, L>(storage: &L, f: F) -> R
 where
-    F: FnOnce() -> Fallible<R>,
+    F: FnOnce() -> R,
     L: Log + Clone + 'static,
 {
     let storage = Box::new(storage.clone());

--- a/src/logs/storage.rs
+++ b/src/logs/storage.rs
@@ -1,8 +1,10 @@
+use crate::config::Config;
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 struct StoredRecord {
     level: Level,
     message: String,
@@ -10,21 +12,29 @@ struct StoredRecord {
 
 struct InnerStorage {
     records: Vec<StoredRecord>,
+    size: usize,
+    truncated: bool,
 }
 
 #[derive(Clone)]
 pub struct LogStorage {
     inner: Arc<Mutex<InnerStorage>>,
     min_level: LevelFilter,
+    max_size: usize,
+    max_lines: usize,
 }
 
 impl LogStorage {
-    pub(crate) fn new(min_level: LevelFilter) -> Self {
+    pub(crate) fn new(min_level: LevelFilter, config: &Config) -> Self {
         LogStorage {
             inner: Arc::new(Mutex::new(InnerStorage {
                 records: Vec::new(),
+                truncated: false,
+                size: 0,
             })),
             min_level,
+            max_size: config.sandbox.build_log_max_size.to_bytes(),
+            max_lines: config.sandbox.build_log_max_lines,
         }
     }
 
@@ -33,8 +43,12 @@ impl LogStorage {
         LogStorage {
             inner: Arc::new(Mutex::new(InnerStorage {
                 records: inner.records.clone(),
+                truncated: inner.truncated,
+                size: inner.size,
             })),
             min_level: self.min_level,
+            max_size: self.max_size,
+            max_lines: self.max_lines,
         }
     }
 }
@@ -49,9 +63,30 @@ impl Log for LogStorage {
             return;
         }
         let mut inner = self.inner.lock().unwrap();
+        if inner.truncated {
+            return;
+        }
+        if inner.records.len() >= self.max_lines {
+            inner.records.push(StoredRecord {
+                level: Level::Warn,
+                message: "too many lines in the log, truncating it".into(),
+            });
+            inner.truncated = true;
+            return;
+        }
+        let message = record.args().to_string();
+        if inner.size + message.len() >= self.max_size {
+            inner.records.push(StoredRecord {
+                level: Level::Warn,
+                message: "too much data in the log, truncating it".into(),
+            });
+            inner.truncated = true;
+            return;
+        }
+        inner.size += message.len();
         inner.records.push(StoredRecord {
             level: record.level(),
-            message: record.args().to_string(),
+            message,
         });
     }
 
@@ -65,5 +100,91 @@ impl fmt::Display for LogStorage {
             writeln!(f, "[{}] {}", record.level, record.message)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogStorage, StoredRecord};
+    use crate::config::Config;
+    use crate::logs;
+    use crate::prelude::*;
+    use crate::utils::size::Size;
+    use log::{Level, LevelFilter};
+
+    #[test]
+    fn test_log_storage() {
+        logs::init_test();
+        let config = Config::default();
+
+        let storage = LogStorage::new(LevelFilter::Info, &config);
+        logs::capture(&storage, || {
+            info!("an info record");
+            warn!("a warn record");
+            trace!("a trace record");
+        });
+
+        assert_eq!(
+            storage.inner.lock().unwrap().records,
+            vec![
+                StoredRecord {
+                    level: Level::Info,
+                    message: "an info record".to_string(),
+                },
+                StoredRecord {
+                    level: Level::Warn,
+                    message: "a warn record".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_too_much_content() {
+        logs::init_test();
+
+        let mut config = Config::default();
+        config.sandbox.build_log_max_size = Size::Kilobytes(4);
+
+        let storage = LogStorage::new(LevelFilter::Info, &config);
+        logs::capture(&storage, || {
+            let content = (0..Size::Kilobytes(8).to_bytes())
+                .map(|_| '.')
+                .collect::<String>();
+            info!("{}", content);
+        });
+
+        let inner = storage.inner.lock().unwrap();
+        assert_eq!(inner.records.len(), 1);
+        assert!(inner
+            .records
+            .last()
+            .unwrap()
+            .message
+            .contains("too much data"));
+    }
+
+    #[test]
+    fn test_too_many_lines() {
+        logs::init_test();
+
+        let mut config = Config::default();
+        config.sandbox.build_log_max_lines = 100;
+
+        let storage = LogStorage::new(LevelFilter::Info, &config);
+        logs::capture(&storage, || {
+            for _ in 0..200 {
+                info!("a line");
+            }
+        });
+
+        let inner = storage.inner.lock().unwrap();
+        assert_eq!(inner.records.len(), 101);
+        assert!(inner
+            .records
+            .last()
+            .unwrap()
+            .message
+            .contains("too many lines"));
     }
 }

--- a/src/report/archives.rs
+++ b/src/report/archives.rs
@@ -127,25 +127,25 @@ mod tests {
         // Fill some dummy results into the database
         let results = DatabaseDB::new(&db);
         results
-            .record_result(&ex, &ex.toolchains[0], &crate1, None, || {
+            .record_result(&ex, &ex.toolchains[0], &crate1, None, &config, || {
                 info!("tc1 crate1");
                 Ok(TestResult::TestPass)
             })
             .unwrap();
         results
-            .record_result(&ex, &ex.toolchains[1], &crate1, None, || {
+            .record_result(&ex, &ex.toolchains[1], &crate1, None, &config, || {
                 info!("tc2 crate1");
                 Ok(TestResult::BuildFail(FailureReason::Unknown))
             })
             .unwrap();
         results
-            .record_result(&ex, &ex.toolchains[0], &crate2, None, || {
+            .record_result(&ex, &ex.toolchains[0], &crate2, None, &config, || {
                 info!("tc1 crate2");
                 Ok(TestResult::TestPass)
             })
             .unwrap();
         results
-            .record_result(&ex, &ex.toolchains[1], &crate2, None, || {
+            .record_result(&ex, &ex.toolchains[1], &crate2, None, &config, || {
                 info!("tc2 crate2");
                 Ok(TestResult::TestPass)
             })

--- a/src/results/mod.rs
+++ b/src/results/mod.rs
@@ -2,6 +2,7 @@ mod db;
 #[cfg(test)]
 mod dummy;
 
+use crate::config::Config;
 use crate::crates::{Crate, GitHubRepo};
 use crate::experiments::Experiment;
 use crate::logs::LogStorage;
@@ -43,6 +44,7 @@ pub trait WriteResults {
         toolchain: &Toolchain,
         krate: &Crate,
         existing_logs: Option<LogStorage>,
+        config: &Config,
         f: F,
     ) -> Fallible<TestResult>
     where

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -191,6 +191,7 @@ impl TasksGraph {
         ex: &Experiment,
         db: &DB,
         state: &RunnerState,
+        config: &Config,
         error: &F,
         result: TestResult,
     ) -> Fallible<()> {
@@ -199,11 +200,13 @@ impl TasksGraph {
             .neighbors_directed(node, Direction::Incoming)
             .collect::<Vec<_>>();
         for child in children.drain(..) {
-            self.mark_as_failed(child, ex, db, state, error, result)?;
+            self.mark_as_failed(child, ex, db, state, config, error, result)?;
         }
 
         match self.graph[node] {
-            Node::Task { ref task, .. } => task.mark_as_failed(ex, db, state, error, result)?,
+            Node::Task { ref task, .. } => {
+                task.mark_as_failed(ex, db, state, config, error, result)?
+            }
             Node::CrateCompleted | Node::Root => return Ok(()),
         }
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -128,7 +128,7 @@ fn run_ex_inner<DB: WriteResults + Sync>(
                                 graph
                                     .lock()
                                     .unwrap()
-                                    .mark_as_failed(id, ex, db, &state, &e, result)?;
+                                    .mark_as_failed(id, ex, db, &state, &config, &e, result)?;
                             } else {
                                 graph.lock().unwrap().mark_as_completed(id);
                             }

--- a/src/runner/tasks.rs
+++ b/src/runner/tasks.rs
@@ -25,7 +25,6 @@ pub(super) struct TaskCtx<'ctx, DB: WriteResults + 'ctx> {
 }
 
 impl<'ctx, DB: WriteResults + 'ctx> TaskCtx<'ctx, DB> {
-    #[allow(clippy::too_many_arguments)]
     fn new(
         config: &'ctx Config,
         db: &'ctx DB,
@@ -133,6 +132,7 @@ impl Task {
         ex: &Experiment,
         db: &DB,
         state: &RunnerState,
+        config: &Config,
         err: &F,
         result: TestResult,
     ) -> Fallible<()> {
@@ -148,7 +148,7 @@ impl Task {
                     .prepare_logs
                     .get(&self.krate)
                     .map(|s| s.duplicate());
-                db.record_result(ex, tc, &self.krate, log_storage, || {
+                db.record_result(ex, tc, &self.krate, log_storage, config, || {
                     error!("this task or one of its parent failed!");
                     utils::report_failure(err);
                     Ok(result)
@@ -177,7 +177,7 @@ impl Task {
                 state.lock().prepare_logs.remove(&self.krate);
             }
             TaskStep::Prepare => {
-                let storage = LogStorage::new(LevelFilter::Info);
+                let storage = LogStorage::new(LevelFilter::Info, config);
                 state
                     .lock()
                     .prepare_logs

--- a/src/runner/test.rs
+++ b/src/runner/test.rs
@@ -57,7 +57,6 @@ fn run_cargo<DB: WriteResults>(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(super) fn run_test<DB: WriteResults>(
     action: &str,
     ctx: &TaskCtx<DB>,
@@ -81,6 +80,7 @@ pub(super) fn run_test<DB: WriteResults>(
             ctx.toolchain,
             ctx.krate,
             log_storage,
+            ctx.config,
             || {
                 info!(
                     "{} {} against {} for {}",

--- a/src/utils/size.rs
+++ b/src/utils/size.rs
@@ -11,6 +11,18 @@ pub enum Size {
     Terabytes(usize),
 }
 
+impl Size {
+    pub(crate) fn to_bytes(&self) -> usize {
+        match self {
+            Size::Bytes(b) => *b,
+            Size::Kilobytes(kb) => kb * 1024,
+            Size::Megabytes(mb) => mb * 1024 * 1024,
+            Size::Gigabytes(gb) => gb * 1024 * 1024 * 1024,
+            Size::Terabytes(tb) => tb * 1024 * 1024 * 1024 * 1024,
+        }
+    }
+}
+
 impl fmt::Display for Size {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -61,29 +73,37 @@ mod tests {
         assert_eq!("1234B".parse::<Size>().unwrap(), Size::Bytes(1234));
         assert_eq!("1234b".parse::<Size>().unwrap(), Size::Bytes(1234));
         assert_eq!(Size::Bytes(1234).to_string(), "1234");
+        assert_eq!(Size::Bytes(42).to_bytes(), 42);
 
         assert_eq!("1234K".parse::<Size>().unwrap(), Size::Kilobytes(1234));
         assert_eq!("1234k".parse::<Size>().unwrap(), Size::Kilobytes(1234));
         assert_eq!("1234KB".parse::<Size>().unwrap(), Size::Kilobytes(1234));
         assert_eq!("1234kb".parse::<Size>().unwrap(), Size::Kilobytes(1234));
         assert_eq!(Size::Kilobytes(1234).to_string(), "1234K");
+        assert_eq!(Size::Kilobytes(42).to_bytes(), 42 * 1024);
 
         assert_eq!("1234M".parse::<Size>().unwrap(), Size::Megabytes(1234));
         assert_eq!("1234m".parse::<Size>().unwrap(), Size::Megabytes(1234));
         assert_eq!("1234MB".parse::<Size>().unwrap(), Size::Megabytes(1234));
         assert_eq!("1234mb".parse::<Size>().unwrap(), Size::Megabytes(1234));
         assert_eq!(Size::Megabytes(1234).to_string(), "1234M");
+        assert_eq!(Size::Megabytes(42).to_bytes(), 42 * 1024 * 1024);
 
         assert_eq!("1234G".parse::<Size>().unwrap(), Size::Gigabytes(1234));
         assert_eq!("1234g".parse::<Size>().unwrap(), Size::Gigabytes(1234));
         assert_eq!("1234GB".parse::<Size>().unwrap(), Size::Gigabytes(1234));
         assert_eq!("1234Gb".parse::<Size>().unwrap(), Size::Gigabytes(1234));
         assert_eq!(Size::Gigabytes(1234).to_string(), "1234G");
+        assert_eq!(Size::Gigabytes(42).to_bytes(), 42 * 1024 * 1024 * 1024);
 
         assert_eq!("1234T".parse::<Size>().unwrap(), Size::Terabytes(1234));
         assert_eq!("1234t".parse::<Size>().unwrap(), Size::Terabytes(1234));
         assert_eq!("1234TB".parse::<Size>().unwrap(), Size::Terabytes(1234));
         assert_eq!("1234Tb".parse::<Size>().unwrap(), Size::Terabytes(1234));
         assert_eq!(Size::Terabytes(1234).to_string(), "1234T");
+        assert_eq!(
+            Size::Terabytes(42).to_bytes(),
+            42 * 1024 * 1024 * 1024 * 1024
+        );
     }
 }

--- a/tests/check_config/bad-duplicate-crate.toml
+++ b/tests/check_config/bad-duplicate-crate.toml
@@ -15,6 +15,8 @@ local-crates = []
 
 [sandbox]
 memory-limit = "1536M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
 
 [crates]
 lazy_static = { skip = true }

--- a/tests/check_config/bad-duplicate-repo.toml
+++ b/tests/check_config/bad-duplicate-repo.toml
@@ -15,6 +15,8 @@ local-crates = []
 
 [sandbox]
 memory-limit = "1536M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
 
 [crates]
 

--- a/tests/check_config/bad-missing-crate.toml
+++ b/tests/check_config/bad-missing-crate.toml
@@ -15,6 +15,8 @@ local-crates = []
 
 [sandbox]
 memory-limit = "1536M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
 
 [crates]
 crater_missing_crate = { skip = true }

--- a/tests/check_config/bad-missing-repo.toml
+++ b/tests/check_config/bad-missing-repo.toml
@@ -15,6 +15,8 @@ local-crates = []
 
 [sandbox]
 memory-limit = "1536M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
 
 [crates]
 

--- a/tests/check_config/good.toml
+++ b/tests/check_config/good.toml
@@ -15,6 +15,8 @@ local-crates = []
 
 [sandbox]
 memory-limit = "1536M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
 
 [crates]
 lazy_static = { skip = true }

--- a/tests/minicrater/full/config.toml
+++ b/tests/minicrater/full/config.toml
@@ -15,6 +15,8 @@ local-crates = []
 
 [sandbox]
 memory-limit = "512M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
 
 [crates]
 

--- a/tests/minicrater/small/config.toml
+++ b/tests/minicrater/small/config.toml
@@ -15,6 +15,8 @@ local-crates = ["build-pass", "beta-regression"]
 
 [sandbox]
 memory-limit = "512M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
 
 [crates]
 


### PR DESCRIPTION
This PR implements proper restrictions on the amount of data that can be stored in build logs. Instead of killing the process after it outputted too much data (like what was proposed in #160) this PR just stops recording log entries after the thresholds are reached, outputting a warning at the end. This allows us to keep testing the crates and detect possible regressions.

With the current configuration (tweakable through `cargo.toml`) logs are truncated when either of those conditions are reached:

* More than 10000 log lines
* More than 5MB of data

@Mark-Simulacrum or @aidanhs, are you OK with those values or should we tweak them?

Fixes #160