### PR TITLE
Add a flag to ignore the blacklist for a run

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -115,6 +115,7 @@ beta run you can use:
 * `mode`: the experiment mode (default: `build-and-test`)
 * `crates`: the selection of crates to use (default: `full`)
 * `cap-lints`: the lints cap (default: `forbid`, which means no cap)
+* `ignore-blacklist`: whether the blacklist should be ignored (default: `false`)
 * `p`: the priority of the run (default: `0`)
 
 [Go back to the TOC][h-toc]
@@ -140,6 +141,7 @@ priority of the `foo` experiment you can use:
 * `mode`: the experiment mode (default: `build-and-test`)
 * `crates`: the selection of crates to use (default: `full`)
 * `cap-lints`: the lints cap (default: `forbid`, which means no cap)
+* `ignore-blacklist`: whether the blacklist should be ignored (default: `false`)
 * `p`: the priority of the run (default: `0`)
 
 [Go back to the TOC][h-toc]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -121,6 +121,8 @@ pub enum Crater {
         cap_lints: CapLints,
         #[structopt(name = "priority", long = "priority", short = "p", default_value = "0")]
         priority: i32,
+        #[structopt(name = "ignore-blacklist", long = "ignore-blacklist")]
+        ignore_blacklist: bool,
     },
 
     #[structopt(name = "edit", about = "edit an experiment configuration")]
@@ -151,6 +153,18 @@ pub enum Crater {
         cap_lints: Option<CapLints>,
         #[structopt(name = "priority", long = "priority", short = "p")]
         priority: Option<i32>,
+        #[structopt(
+            name = "ignore-blacklist",
+            long = "ignore-blacklist",
+            conflicts_with = "no-ignore-blacklist"
+        )]
+        ignore_blacklist: bool,
+        #[structopt(
+            name = "no-ignore-blacklist",
+            long = "no-ignore-blacklist",
+            conflicts_with = "ignore-blacklist"
+        )]
+        no_ignore_blacklist: bool,
     },
 
     #[structopt(name = "delete-ex", about = "delete shared data for experiment")]
@@ -290,6 +304,7 @@ impl Crater {
                 ref crates,
                 ref cap_lints,
                 ref priority,
+                ref ignore_blacklist,
             } => {
                 let config = Config::load()?;
                 let db = Database::open()?;
@@ -302,6 +317,7 @@ impl Crater {
                     cap_lints: *cap_lints,
                     priority: *priority,
                     github_issue: None,
+                    ignore_blacklist: *ignore_blacklist,
                 }
                 .apply(&db, &config)?;
             }
@@ -313,9 +329,19 @@ impl Crater {
                 ref crates,
                 ref cap_lints,
                 ref priority,
+                ref ignore_blacklist,
+                ref no_ignore_blacklist,
             } => {
                 let config = Config::load()?;
                 let db = Database::open()?;
+
+                let ignore_blacklist = if *ignore_blacklist {
+                    Some(true)
+                } else if *no_ignore_blacklist {
+                    Some(false)
+                } else {
+                    None
+                };
 
                 actions::EditExperiment {
                     name: name.clone(),
@@ -324,6 +350,7 @@ impl Crater {
                     crates: *crates,
                     cap_lints: *cap_lints,
                     priority: *priority,
+                    ignore_blacklist,
                 }
                 .apply(&db, &config)?;
             }

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -244,6 +244,15 @@ fn migrations() -> Vec<(&'static str, MigrationKind)> {
         ),
     ));
 
+    migrations.push((
+        "add_experiment_field_ignore_blacklist",
+        MigrationKind::SQL(
+            "
+            ALTER TABLE experiments ADD COLUMN ignore_blacklist INTEGER NOT NULL DEFAULT 0;
+            ",
+        ),
+    ));
+
     migrations
 }
 

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -121,6 +121,7 @@ pub struct Experiment {
     pub status: Status,
     pub assigned_to: Option<Assignee>,
     pub report_url: Option<String>,
+    pub ignore_blacklist: bool,
 }
 
 impl Experiment {
@@ -329,6 +330,7 @@ struct ExperimentDBRecord {
     status: String,
     assigned_to: Option<String>,
     report_url: Option<String>,
+    ignore_blacklist: bool,
 }
 
 impl ExperimentDBRecord {
@@ -349,6 +351,7 @@ impl ExperimentDBRecord {
             github_issue_number: row.get("github_issue_number"),
             assigned_to: row.get("assigned_to"),
             report_url: row.get("report_url"),
+            ignore_blacklist: row.get("ignore_blacklist"),
         }
     }
 
@@ -395,6 +398,7 @@ impl ExperimentDBRecord {
             },
             status: self.status.parse()?,
             report_url: self.report_url,
+            ignore_blacklist: self.ignore_blacklist,
         })
     }
 }

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -638,6 +638,7 @@ mod tests {
             status: Status::GeneratingReport,
             assigned_to: None,
             report_url: None,
+            ignore_blacklist: false,
         };
 
         let mut db = DummyDB::default();

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -227,7 +227,7 @@ pub(super) fn build_graph(ex: &Experiment, config: &Config) -> TasksGraph {
     let mut graph = TasksGraph::new();
 
     for krate in &ex.crates {
-        if config.should_skip(krate) {
+        if !ex.ignore_blacklist && config.should_skip(krate) {
             continue;
         }
 
@@ -250,7 +250,9 @@ pub(super) fn build_graph(ex: &Experiment, config: &Config) -> TasksGraph {
                             tc: tc.clone(),
                             quiet,
                         },
-                        Mode::BuildAndTest if config.should_skip_tests(krate) => {
+                        Mode::BuildAndTest
+                            if !ex.ignore_blacklist && config.should_skip_tests(krate) =>
+                        {
                             TaskStep::BuildOnly {
                                 tc: tc.clone(),
                                 quiet,

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -109,6 +109,7 @@ generate_parser!(pub enum Command {
         crates: Option<CrateSelect> = "crates",
         cap_lints: Option<CapLints> = "cap-lints",
         priority: Option<i32> = "p",
+        ignore_blacklist: Option<bool> = "ignore-blacklist",
     })
 
     "abort" => Abort(AbortArgs {
@@ -131,6 +132,7 @@ generate_parser!(pub enum Command {
         crates: Option<CrateSelect> = "crates",
         cap_lints: Option<CapLints> = "cap-lints",
         priority: Option<i32> = "p",
+        ignore_blacklist: Option<bool> = "ignore-blacklist",
     })
 });
 

--- a/src/server/routes/webhooks/commands.rs
+++ b/src/server/routes/webhooks/commands.rs
@@ -33,6 +33,7 @@ pub fn run(host: &str, data: &Data, issue: &Issue, args: RunArgs) -> Fallible<()
             html_url: issue.html_url.clone(),
             number: issue.number,
         }),
+        ignore_blacklist: args.ignore_blacklist.unwrap_or(false),
     }
     .apply(&data.db, &data.config)?;
 
@@ -64,6 +65,7 @@ pub fn edit(data: &Data, issue: &Issue, args: EditArgs) -> Fallible<()> {
         mode: args.mode,
         cap_lints: args.cap_lints,
         priority: args.priority,
+        ignore_blacklist: args.ignore_blacklist,
     }
     .apply(&data.db, &data.config)?;
 

--- a/tests/minicrater/blacklist/config.toml
+++ b/tests/minicrater/blacklist/config.toml
@@ -1,0 +1,27 @@
+[server]
+bot-acl = [
+    "pietroalbini",
+]
+
+[server.labels]
+remove = "^S-"
+experiment-queued = "S-waiting-on-crater"
+experiment-completed = "S-waiting-on-review"
+
+[demo-crates]
+crates = []
+github-repos = []
+local-crates = ["build-pass", "build-fail", "test-fail"]
+
+[sandbox]
+memory-limit = "512M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
+
+[crates]
+
+[github-repos]
+
+[local-crates]
+build-fail = { skip = true }
+test-fail = { skip-tests = true }

--- a/tests/minicrater/blacklist/results.expected.json
+++ b/tests/minicrater/blacklist/results.expected.json
@@ -1,0 +1,43 @@
+{
+  "crates": [
+    {
+      "name": "build-pass (local)",
+      "res": "test-pass",
+      "runs": [
+        {
+          "log": "stable/local/build-pass",
+          "res": "test-pass"
+        },
+        {
+          "log": "beta/local/build-pass",
+          "res": "test-pass"
+        }
+      ],
+      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-pass"
+    },
+    {
+      "name": "test-fail (local)",
+      "res": "test-skipped",
+      "runs": [
+        {
+          "log": "stable/local/test-fail",
+          "res": "test-skipped"
+        },
+        {
+          "log": "beta/local/test-fail",
+          "res": "test-skipped"
+        }
+      ],
+      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/test-fail"
+    },
+    {
+      "name": "build-fail (local)",
+      "res": "skipped",
+      "runs": [
+        null,
+        null
+      ],
+      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-fail"
+    }
+  ]
+}

--- a/tests/minicrater/ignore-blacklist/config.toml
+++ b/tests/minicrater/ignore-blacklist/config.toml
@@ -1,0 +1,27 @@
+[server]
+bot-acl = [
+    "pietroalbini",
+]
+
+[server.labels]
+remove = "^S-"
+experiment-queued = "S-waiting-on-crater"
+experiment-completed = "S-waiting-on-review"
+
+[demo-crates]
+crates = []
+github-repos = []
+local-crates = ["build-pass", "build-fail", "test-fail"]
+
+[sandbox]
+memory-limit = "512M"
+build-log-max-size = "2M"
+build-log-max-lines = 1000
+
+[crates]
+
+[github-repos]
+
+[local-crates]
+build-fail = { skip = true }
+test-fail = { skip-tests = true }

--- a/tests/minicrater/ignore-blacklist/results.expected.json
+++ b/tests/minicrater/ignore-blacklist/results.expected.json
@@ -1,0 +1,49 @@
+{
+  "crates": [
+    {
+      "name": "build-fail (local)",
+      "res": "build-fail",
+      "runs": [
+        {
+          "log": "stable/local/build-fail",
+          "res": "build-fail:unknown"
+        },
+        {
+          "log": "beta/local/build-fail",
+          "res": "build-fail:unknown"
+        }
+      ],
+      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-fail"
+    },
+    {
+      "name": "build-pass (local)",
+      "res": "test-pass",
+      "runs": [
+        {
+          "log": "stable/local/build-pass",
+          "res": "test-pass"
+        },
+        {
+          "log": "beta/local/build-pass",
+          "res": "test-pass"
+        }
+      ],
+      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/build-pass"
+    },
+    {
+      "name": "test-fail (local)",
+      "res": "test-fail",
+      "runs": [
+        {
+          "log": "stable/local/test-fail",
+          "res": "test-fail:unknown"
+        },
+        {
+          "log": "beta/local/test-fail",
+          "res": "test-fail:unknown"
+        }
+      ],
+      "url": "https://github.com/rust-lang-nursery/crater/tree/master/local-crates/test-fail"
+    }
+  ]
+}

--- a/tests/minicrater/mod.rs
+++ b/tests/minicrater/mod.rs
@@ -25,6 +25,7 @@ struct MinicraterRun {
     ex: &'static str,
     crate_select: &'static str,
     multithread: bool,
+    ignore_blacklist: bool,
 }
 
 impl MinicraterRun {
@@ -53,14 +54,13 @@ impl MinicraterRun {
             .minicrater_exec();
 
         // Define the experiment
+        let crate_select = format!("--crate-select={}", self.crate_select);
+        let mut define_args = vec!["define-ex", &ex_arg, "stable", "beta", &crate_select];
+        if self.ignore_blacklist {
+            define_args.push("--ignore-blacklist");
+        }
         Command::crater()
-            .args(&[
-                "define-ex",
-                &ex_arg,
-                "stable",
-                "beta",
-                &format!("--crate-select={}", self.crate_select),
-            ])
+            .args(&define_args)
             .env("CRATER_CONFIG", &config_file)
             .minicrater_exec();
 
@@ -133,6 +133,7 @@ fn single_thread_small() {
         ex: "small",
         crate_select: "demo",
         multithread: false,
+        ignore_blacklist: false,
     }
     .execute();
 }
@@ -144,6 +145,7 @@ fn single_thread_full() {
         ex: "full",
         crate_select: "local",
         multithread: false,
+        ignore_blacklist: false,
     }
     .execute();
 }
@@ -155,6 +157,19 @@ fn single_thread_blacklist() {
         ex: "blacklist",
         crate_select: "demo",
         multithread: false,
+        ignore_blacklist: false,
+    }
+    .execute();
+}
+
+#[ignore]
+#[test]
+fn single_thread_ignore_blacklist() {
+    MinicraterRun {
+        ex: "ignore-blacklist",
+        crate_select: "demo",
+        multithread: false,
+        ignore_blacklist: true,
     }
     .execute();
 }
@@ -166,6 +181,7 @@ fn multi_thread_full() {
         ex: "full",
         crate_select: "local",
         multithread: true,
+        ignore_blacklist: false,
     }
     .execute();
 }

--- a/tests/minicrater/mod.rs
+++ b/tests/minicrater/mod.rs
@@ -131,6 +131,12 @@ fn single_thread_full() {
 
 #[ignore]
 #[test]
+fn single_thread_blacklist() {
+    execute("blacklist", "demo", false);
+}
+
+#[ignore]
+#[test]
 fn multi_thread_full() {
     execute("full", "local", true);
 }


### PR DESCRIPTION
This PR adds a flag to ignore the blacklist only for a run. The flag will be useful when maintenance runs are done, for example when we regenerate the list of automatically skipped crates.

It also adds minicrater runs with the blacklist and with the blacklist ignored.