### PR TITLE
Report agent crashes to the server

### DIFF
--- a/docs/agent-http-api.md
+++ b/docs/agent-http-api.md
@@ -60,6 +60,7 @@ behave this way:
 * `POST /agent-api/complete-experiment` should be called as soon as the agent
   has nothing left to do with the current experiment; after the method returns
   `next-experiment` will return a new experiment
+ * `POST /error` should be called only when the agent has encountered an error
 
 ## Available endpoints
 
@@ -218,6 +219,29 @@ The endpoint replies with `true`.
 This endpoint tells the Crater server the agent is still alive. The method
 should be called by the agent every minute, and after some time the method is
 not called the Crater server will mark the agent as unreachable.
+
+The endpoint replies with `true`.
+
+```json
+{
+    "status": "success",
+    "result": true
+}
+```
+
+### `POST /error`
+
+This endpoint tells the Crater server the agent has encountered an error. The endpoint expects the error description to be provided as the request body, encoded in JSON:
+
+* `error`: a description of the error
+
+For example, this is a valid request data:
+
+```json
+{
+    "error": "pc is not powered on"
+}
+```
 
 The endpoint replies with `true`.
 

--- a/docs/agent-http-api.md
+++ b/docs/agent-http-api.md
@@ -60,7 +60,7 @@ behave this way:
 * `POST /agent-api/complete-experiment` should be called as soon as the agent
   has nothing left to do with the current experiment; after the method returns
   `next-experiment` will return a new experiment
- * `POST /error` should be called only when the agent has encountered an error
+* `POST /error` should be called only when the agent has encountered an error
 
 ## Available endpoints
 
@@ -231,7 +231,9 @@ The endpoint replies with `true`.
 
 ### `POST /error`
 
-This endpoint tells the Crater server the agent has encountered an error. The endpoint expects the error description to be provided as the request body, encoded in JSON:
+This endpoint tells the Crater server the agent has encountered an error.
+The endpoint expects the error description to be provided as the request body,
+encoded in JSON:
 
 * `error`: a description of the error
 

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -190,4 +190,15 @@ impl AgentApi {
             Ok(())
         })
     }
+
+    pub fn report_error(&self, error: String) -> Fallible<()> {
+        self.retry(|this| {
+            let _: bool = this
+                .build_request(Method::POST, "error")
+                .json(&json!({ "error": error }))
+                .send()?
+                .to_api_response()?;
+            Ok(())
+        })
+    }
 }

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -227,7 +227,10 @@ impl Experiment {
             )?;
             self.started_at = Some(now);
         // Check if the old status was "running" and there is no completed date
-        } else if self.status == Status::Running && self.completed_at.is_none() {
+        } else if self.status == Status::Running
+            && self.completed_at.is_none()
+            && status != Status::Failed
+        {
             db.execute(
                 "UPDATE experiments SET completed_at = ?1 WHERE name = ?2;",
                 &[&now, &self.name.as_str()],

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -12,6 +12,7 @@ string_enum!(pub enum Status {
     Queued => "queued",
     Running => "running",
     NeedsReport => "needs-report",
+    Failed => "failed",
     GeneratingReport => "generating-report",
     ReportFailed => "report-failed",
     Completed => "completed",

--- a/src/server/routes/ui/experiments.rs
+++ b/src/server/routes/ui/experiments.rs
@@ -25,6 +25,7 @@ impl ExperimentData {
             Status::Queued => ("", "Queued", true),
             Status::Running => ("orange", "Running", true),
             Status::NeedsReport => ("orange", "Needs report", false),
+            Status::Failed => ("red", "Failed", false),
             Status::GeneratingReport => ("orange", "Generating report", false),
             Status::ReportFailed => ("red", "Report failed", false),
             Status::Completed => ("green", "Completed", false),
@@ -62,6 +63,7 @@ pub fn endpoint_queue(data: Arc<Data>) -> Fallible<Response<Body>> {
     let mut queued = Vec::new();
     let mut running = Vec::new();
     let mut needs_report = Vec::new();
+    let mut failed = Vec::new();
     let mut generating_report = Vec::new();
     let mut report_failed = Vec::new();
 
@@ -77,6 +79,7 @@ pub fn endpoint_queue(data: Arc<Data>) -> Fallible<Response<Body>> {
             Status::Queued => queued.push(ex),
             Status::Running => running.push(ex),
             Status::NeedsReport => needs_report.push(ex),
+            Status::Failed => failed.push(ex),
             Status::GeneratingReport => generating_report.push(ex),
             Status::ReportFailed => report_failed.push(ex),
             Status::Completed => unreachable!(),
@@ -87,6 +90,7 @@ pub fn endpoint_queue(data: Arc<Data>) -> Fallible<Response<Body>> {
     experiments.append(&mut report_failed);
     experiments.append(&mut generating_report);
     experiments.append(&mut needs_report);
+    experiments.append(&mut failed);
     experiments.append(&mut running);
     experiments.append(&mut queued);
 

--- a/src/server/routes/webhooks/args.rs
+++ b/src/server/routes/webhooks/args.rs
@@ -122,6 +122,10 @@ generate_parser!(pub enum Command {
         name: Option<String> = "name",
     })
 
+    "retry" => Retry(RetryArgs {
+        name: Option<String> = "name",
+    })
+
     "reload-acl" => ReloadACL(ReloadACLArgs {})
 
     _ => Edit(EditArgs {

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -111,6 +111,10 @@ fn process_command(
                 commands::retry_report(data, issue, args)?;
             }
 
+            Command::Retry(args) => {
+                commands::retry(data, issue, args)?;
+            }
+
             Command::Abort(args) => {
                 commands::abort(data, issue, args)?;
             }


### PR DESCRIPTION
fixed #246 
Any error encountered by the agent will be reported to the server that will post it to the relevant GitHub thread. Add new `failed` experiment status and command `retry` to queue again jobs marked as failed  