### PR TITLE
Add context info for tokens.toml load failure

### DIFF
--- a/src/server/tokens.rs
+++ b/src/server/tokens.rs
@@ -81,7 +81,8 @@ impl Default for Tokens {
 
 impl Tokens {
     pub fn load() -> Fallible<Tokens> {
-        let content = ::std::fs::read_to_string(Path::new(TOKENS_PATH))?;
+        let content = ::std::fs::read_to_string(Path::new(TOKENS_PATH))
+            .with_context(|_| format!("could not find {}", TOKENS_PATH))?;
         let res = ::toml::from_str(&content)?;
         Ok(res)
     }


### PR DESCRIPTION
My fresh clone of crater failed to run and i didn't know why, then 30 mins later I found out that I forgot to rename tokens.example.toml to tokens.toml. This should fix that with a friendly error `could not find tokens.toml`