### PR TITLE
Add documentation for new clippy mode

### DIFF
--- a/docs/bot-usage.md
+++ b/docs/bot-usage.md
@@ -67,6 +67,7 @@ The following experiment modes are currently available:
 * `build-and-test`: run `cargo build` and `cargo test` on every crate
 * `build-only`: run `cargo build` on every crate
 * `check-only`: run `cargo check` on every crate (faster)
+* `clippy`: run `cargo clippy` on every crate
 * `rustdoc`: run `cargo doc --no-deps` on every crate
 
 The mode you should use depends on what your experiment is testing:


### PR DESCRIPTION
Instructions for populating `rustflags` are included elsewhere in the docs, so this single line should suffice.

This should have been included in #391 (whoops).