### PR TITLE
Integrate the team repository with Crater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -295,8 +295,9 @@ dependencies = [
  "rusoto_credential 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_s3 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust_team_data 1.0.0 (git+https://github.com/rust-lang/team)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_regex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -322,7 +323,7 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -377,7 +378,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -494,7 +495,7 @@ name = "escargot"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -791,6 +792,9 @@ dependencies = [
 name = "indexmap"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "input_buffer"
@@ -1532,7 +1536,7 @@ dependencies = [
  "mime 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1557,7 +1561,7 @@ dependencies = [
  "md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1576,7 +1580,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1602,6 +1606,15 @@ dependencies = [
  "libsqlite3-sys 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rust_team_data"
+version = "1.0.0"
+source = "git+https://github.com/rust-lang/team#fbd6a82e736680aeb2cc5450f956cd17ac0dae74"
+dependencies = [
+ "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1702,7 +1715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.80"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1725,7 +1738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1734,7 +1747,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1744,7 +1757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1930,7 +1943,7 @@ dependencies = [
  "pest 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "slug 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unic-segment 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2170,7 +2183,7 @@ name = "toml"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2398,7 +2411,7 @@ dependencies = [
  "mime 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2656,6 +2669,7 @@ dependencies = [
 "checksum rusoto_credential 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9a331ddbb4cbc2f99464092cb3dcded64af9ea1e009f4ef719c9fa1130731992"
 "checksum rusoto_s3 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e73914f306a7973d3ead607879d2ff3ca03ac39cf9b636bf99222ed8ae35bbf9"
 "checksum rusqlite 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39bae767eb27866f5c0be918635ae54af705bc09db11be2c43a3c6b361cf3462"
+"checksum rust_team_data 1.0.0 (git+https://github.com/rust-lang/team)" = "<none>"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
@@ -2670,7 +2684,7 @@ dependencies = [
 "checksum security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab01dfbe5756785b5b4d46e0289e5a18071dfa9a7c2b24213ea00b9ef9b665bf"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
+"checksum serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "2e20fde37801e83c891a2dc4ebd3b81f0da4d1fb67a9e0a2a3b921e2536a58ee"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
 "checksum serde_regex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d1385699a81f2d1b18b55cba1e2544d3ed8776db058e62865c0416e861f5ec6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ winapi = "0.3"
 log = "0.4.6"
 env_logger = "0.6.0"
 openssl = "0.10.16"
+rust_team_data = { git = "https://github.com/rust-lang/team" }
 
 [dev-dependencies]
 assert_cmd = "0.10.1"

--- a/config.toml
+++ b/config.toml
@@ -1,13 +1,9 @@
-[server]
+[server.bot-acl]
+# Allow rust team members defined in https://github.com/rust-lang/team
+rust-teams = true
 # The list of GitHub users allowed to interact with the GitHub bot
 # You can mix usernames and teams
-bot-acl = [
-    "rust-lang/infra",
-    "rust-lang/release",
-    "rust-lang/compiler",
-    "rust-lang/libs",
-    "rust-lang/rustdoc",
-]
+github = []
 
 [server.labels]
 # Remove all labels matching this regex when applying new labels

--- a/config.toml
+++ b/config.toml
@@ -4366,7 +4366,6 @@ sciter-serde = { skip-tests = true } #automatic
 scm = { skip = true } #automatic
 scmp = { skip = true } #automatic
 scoped_allocator = { skip = true } #automatic
-scoped_log = { skip = true } #automatic
 scopeguard = { skip-tests = true } #automatic
 score = { skip = true } #automatic
 scout = { skip-tests = true } #automatic

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,8 +42,15 @@ fn default_false() -> bool {
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ServerConfig {
-    pub bot_acl: Vec<String>,
+    pub bot_acl: BotACL,
     pub labels: ServerLabels,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct BotACL {
+    pub rust_teams: bool,
+    pub github: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -247,7 +254,10 @@ impl Default for Config {
                 build_log_max_lines: 1000,
             },
             server: ServerConfig {
-                bot_acl: Vec::new(),
+                bot_acl: BotACL {
+                    rust_teams: false,
+                    github: vec![],
+                },
                 labels: ServerLabels {
                     remove: Regex::new("^$").unwrap(),
                     experiment_queued: "".into(),
@@ -267,8 +277,9 @@ mod tests {
     fn test_config() {
         // A sample config file loaded from memory
         let config = concat!(
-            "[server]\n",
-            "bot-acl = []\n",
+            "[server.bot-acl]\n",
+            "rust-teams = false\n",
+            "github = []\n",
             "[server.labels]\n",
             "remove = \"\"\n",
             "experiment-queued = \"\"\n",

--- a/src/server/routes/webhooks/mod.rs
+++ b/src/server/routes/webhooks/mod.rs
@@ -71,7 +71,7 @@ fn process_command(
             continue;
         }
 
-        if !data.acl.allowed(sender) {
+        if !data.acl.allowed(sender)? {
             Message::new()
                 .line(
                     "lock",

--- a/tests/check_config/bad-duplicate-crate.toml
+++ b/tests/check_config/bad-duplicate-crate.toml
@@ -1,7 +1,6 @@
-[server]
-bot-acl = [
-    "pietroalbini",
-]
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
 
 [server.labels]
 remove = "^S-"

--- a/tests/check_config/bad-duplicate-repo.toml
+++ b/tests/check_config/bad-duplicate-repo.toml
@@ -1,7 +1,6 @@
-[server]
-bot-acl = [
-    "pietroalbini",
-]
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
 
 [server.labels]
 remove = "^S-"

--- a/tests/check_config/bad-missing-crate.toml
+++ b/tests/check_config/bad-missing-crate.toml
@@ -1,7 +1,6 @@
-[server]
-bot-acl = [
-    "pietroalbini",
-]
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
 
 [server.labels]
 remove = "^S-"

--- a/tests/check_config/bad-missing-repo.toml
+++ b/tests/check_config/bad-missing-repo.toml
@@ -1,7 +1,6 @@
-[server]
-bot-acl = [
-    "pietroalbini",
-]
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
 
 [server.labels]
 remove = "^S-"

--- a/tests/check_config/good.toml
+++ b/tests/check_config/good.toml
@@ -1,7 +1,6 @@
-[server]
-bot-acl = [
-    "pietroalbini",
-]
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
 
 [server.labels]
 remove = "^S-"

--- a/tests/minicrater/blacklist/config.toml
+++ b/tests/minicrater/blacklist/config.toml
@@ -1,7 +1,6 @@
-[server]
-bot-acl = [
-    "pietroalbini",
-]
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
 
 [server.labels]
 remove = "^S-"

--- a/tests/minicrater/clippy/config.toml
+++ b/tests/minicrater/clippy/config.toml
@@ -1,7 +1,6 @@
-[server]
-bot-acl = [
-    "pietroalbini",
-]
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
 
 [server.labels]
 remove = "^S-"

--- a/tests/minicrater/full/config.toml
+++ b/tests/minicrater/full/config.toml
@@ -1,7 +1,6 @@
-[server]
-bot-acl = [
-    "pietroalbini",
-]
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
 
 [server.labels]
 remove = "^S-"

--- a/tests/minicrater/ignore-blacklist/config.toml
+++ b/tests/minicrater/ignore-blacklist/config.toml
@@ -1,7 +1,6 @@
-[server]
-bot-acl = [
-    "pietroalbini",
-]
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
 
 [server.labels]
 remove = "^S-"

--- a/tests/minicrater/small/config.toml
+++ b/tests/minicrater/small/config.toml
@@ -1,7 +1,6 @@
-[server]
-bot-acl = [
-    "pietroalbini",
-]
+[server.bot-acl]
+rust-teams = true
+github = ["pietroalbini"]
 
 [server.labels]
 remove = "^S-"


### PR DESCRIPTION
With this PR, craterbot will support fetching the ACL from [rust-lang/team](https://github.com/rust-lang/team).