### PR TITLE
Separate crates from experiment

### DIFF
--- a/src/actions/experiments/create.rs
+++ b/src/actions/experiments/create.rs
@@ -131,7 +131,7 @@ mod tests {
         );
         assert_eq!(ex.mode, Mode::BuildAndTest);
         assert_eq!(
-            ex.crates,
+            ex.get_crates(&ctx.db).unwrap(),
             crate::crates::lists::get_crates(CrateSelect::Local, &db, &config).unwrap()
         );
         assert_eq!(ex.cap_lints, CapLints::Forbid);

--- a/src/actions/experiments/edit.rs
+++ b/src/actions/experiments/edit.rs
@@ -80,7 +80,7 @@ impl Action for EditExperiment {
                     &ctx.config,
                 )?)
             } else if self.ignore_blacklist.is_some() {
-                Some(ex.crates.clone())
+                Some(ex.get_crates(&ctx.db)?)
             } else {
                 None
             };
@@ -102,7 +102,6 @@ impl Action for EditExperiment {
                         ],
                     )?;
                 }
-                ex.crates = crates_vec;
             }
 
             // Try to update the mode
@@ -212,7 +211,7 @@ mod tests {
         assert_eq!(ex.ignore_blacklist, true);
 
         assert_eq!(
-            ex.crates,
+            ex.get_crates(&ctx.db).unwrap(),
             crate::crates::lists::get_crates(CrateSelect::Local, &db, &config).unwrap()
         );
     }

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -128,15 +128,15 @@ impl AgentApi {
         })
     }
 
-    pub fn next_experiment(&self) -> Fallible<Experiment> {
+    pub fn next_experiment(&self) -> Fallible<(Experiment, Vec<Crate>)> {
         self.retry(|this| loop {
             let resp: Option<_> = this
                 .build_request(Method::GET, "next-experiment")
                 .send()?
                 .to_api_response()?;
 
-            if let Some(experiment) = resp {
-                return Ok(experiment);
+            if let Some((experiment, crates)) = resp {
+                return Ok((experiment, crates));
             }
 
             ::std::thread::sleep(::std::time::Duration::from_secs(RETRY_AFTER));

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -4,6 +4,7 @@ mod results;
 use crate::agent::api::AgentApi;
 use crate::agent::results::ResultsUploader;
 use crate::config::Config;
+use crate::crates::Crate;
 use crate::experiments::Experiment;
 use crate::prelude::*;
 use crate::utils;
@@ -31,7 +32,7 @@ impl Agent {
         })
     }
 
-    fn experiment(&self) -> Fallible<Experiment> {
+    fn experiment(&self) -> Fallible<(Experiment, Vec<Crate>)> {
         info!("asking the server for a new experiment...");
         Ok(self.api.next_experiment()?)
     }
@@ -54,8 +55,8 @@ fn run_experiment(
     threads_count: usize,
     docker_env: &str,
 ) -> Fallible<()> {
-    let ex = agent.experiment()?;
-    crate::runner::run_ex(&ex, db, threads_count, &agent.config, docker_env)?;
+    let (ex, crates) = agent.experiment()?;
+    crate::runner::run_ex(&ex, &crates, db, threads_count, &agent.config, docker_env)?;
     agent.api.complete_experiment()?;
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -428,7 +428,7 @@ impl Crater {
                     let result_db = DatabaseDB::new(&db);
                     runner::run_ex(
                         &experiment,
-                        &experiment.get_crates(&db)?,
+                        &experiment.get_uncompleted_crates(&db)?,
                         &result_db,
                         threads,
                         &config,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -426,7 +426,14 @@ impl Crater {
                     }
 
                     let result_db = DatabaseDB::new(&db);
-                    runner::run_ex(&experiment, &result_db, threads, &config, docker_env)?;
+                    runner::run_ex(
+                        &experiment,
+                        &experiment.get_crates(&db)?,
+                        &result_db,
+                        threads,
+                        &config,
+                        docker_env,
+                    )?;
                     experiment.set_status(&db, Status::NeedsReport)?;
                 } else {
                     bail!("missing experiment {}", ex.0);
@@ -457,6 +464,7 @@ impl Crater {
                     let res = report::gen(
                         &result_db,
                         &experiment,
+                        &experiment.get_crates(&db)?,
                         &report::FileWriter::create(dest.0.clone())?,
                         &config,
                     );
@@ -498,6 +506,7 @@ impl Crater {
                     let res = report::gen(
                         &result_db,
                         &experiment,
+                        &experiment.get_crates(&db)?,
                         &report::S3Writer::create(client, s3_prefix.clone())?,
                         &config,
                     );
@@ -533,7 +542,7 @@ impl Crater {
                 let db = Database::open()?;
 
                 if let Some(experiment) = Experiment::get(&db, &ex.0)? {
-                    runner::dump_dot(&experiment, &config, dest)?;
+                    runner::dump_dot(&experiment, &experiment.get_crates(&db)?, &config, dest)?;
                 } else {
                     bail!("missing experiment: {}", ex.0);
                 }

--- a/src/experiments.rs
+++ b/src/experiments.rs
@@ -297,7 +297,8 @@ impl Experiment {
 
     pub fn get_crates(&self, db: &Database) -> Fallible<Vec<Crate>> {
         db.query(
-            "SELECT crate FROM experiment_crates WHERE experiment = ?1",
+            "SELECT crate FROM experiment_crates WHERE experiment = ?1
+            AND (SELECT COUNT(*) AS count FROM results WHERE results.experiment = ?1 AND results.crate = experiment_crates.crate) >= 2",
             &[&self.name],
             |r| {
                 let value: String = r.get("crate");

--- a/src/report/html.rs
+++ b/src/report/html.rs
@@ -133,6 +133,7 @@ struct DownloadsContext<'a> {
 
 fn write_report<W: ReportWriter>(
     ex: &Experiment,
+    crates_count: usize,
     res: &TestResults,
     full: bool,
     to: &str,
@@ -184,8 +185,7 @@ fn write_report<W: ReportWriter>(
         .navbar(),
         categories,
         full,
-        crates_count: ex.crates.len(),
-
+        crates_count,
         comparison_colors,
         result_colors,
         result_names,
@@ -200,14 +200,14 @@ fn write_report<W: ReportWriter>(
 
 fn write_downloads<W: ReportWriter>(
     ex: &Experiment,
+    crates_count: usize,
     available_archives: Vec<Archive>,
     dest: &W,
 ) -> Fallible<()> {
     let context = DownloadsContext {
         ex,
         nav: CurrentPage::Downloads.navbar(),
-        crates_count: ex.crates.len(),
-
+        crates_count,
         available_archives,
     };
 
@@ -220,15 +220,16 @@ fn write_downloads<W: ReportWriter>(
 
 pub fn write_html_report<W: ReportWriter>(
     ex: &Experiment,
+    crates_count: usize,
     res: &TestResults,
     available_archives: Vec<Archive>,
     dest: &W,
 ) -> Fallible<()> {
     let js_in = assets::load("report.js")?;
     let css_in = assets::load("report.css")?;
-    write_report(ex, res, false, "index.html", dest)?;
-    write_report(ex, res, true, "full.html", dest)?;
-    write_downloads(ex, available_archives, dest)?;
+    write_report(ex, crates_count, res, false, "index.html", dest)?;
+    write_report(ex, crates_count, res, true, "full.html", dest)?;
+    write_downloads(ex, crates_count, available_archives, dest)?;
 
     info!("copying static assets");
     dest.write_bytes(

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -130,7 +130,7 @@ pub fn generate_report<DB: ReadResults>(
 ) -> Fallible<TestResults> {
     let shas = db.load_all_shas(ex)?;
     let res = crates
-        .into_iter()
+        .iter()
         .map(|krate| {
             // Any errors here will turn into unknown results
             let crate_results = ex.toolchains.iter().map(|tc| -> Fallible<BuildTestResult> {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -126,11 +126,10 @@ pub fn generate_report<DB: ReadResults>(
     db: &DB,
     config: &Config,
     ex: &Experiment,
+    crates: &[Crate],
 ) -> Fallible<TestResults> {
     let shas = db.load_all_shas(ex)?;
-    let res = ex
-        .crates
-        .clone()
+    let res = crates
         .into_iter()
         .map(|krate| {
             // Any errors here will turn into unknown results
@@ -175,12 +174,13 @@ const PROGRESS_FRACTION: usize = 10; // write progress every ~1/N crates
 fn write_logs<DB: ReadResults, W: ReportWriter>(
     db: &DB,
     ex: &Experiment,
+    crates: &[Crate],
     dest: &W,
     config: &Config,
 ) -> Fallible<()> {
-    let num_crates = ex.crates.len();
+    let num_crates = crates.len();
     let progress_every = (num_crates / PROGRESS_FRACTION) + 1;
-    for (i, krate) in ex.crates.iter().enumerate() {
+    for (i, krate) in crates.iter().enumerate() {
         if i % progress_every == 0 {
             info!("wrote logs for {}/{} crates", i, num_crates)
         }
@@ -219,10 +219,11 @@ fn write_logs<DB: ReadResults, W: ReportWriter>(
 pub fn gen<DB: ReadResults, W: ReportWriter + Display>(
     db: &DB,
     ex: &Experiment,
+    crates: &[Crate],
     dest: &W,
     config: &Config,
 ) -> Fallible<TestResults> {
-    let res = generate_report(db, config, ex)?;
+    let res = generate_report(db, config, ex, crates)?;
 
     info!("writing results to {}", dest);
     info!("writing metadata");
@@ -238,11 +239,11 @@ pub fn gen<DB: ReadResults, W: ReportWriter + Display>(
     )?;
 
     info!("writing archives");
-    let available_archives = archives::write_logs_archives(db, ex, dest, config)?;
+    let available_archives = archives::write_logs_archives(db, ex, crates, dest, config)?;
     info!("writing html files");
-    html::write_html_report(ex, &res, available_archives, dest)?;
+    html::write_html_report(ex, crates.len(), &res, available_archives, dest)?;
     info!("writing logs");
-    write_logs(db, ex, dest, config)?;
+    write_logs(db, ex, crates, dest, config)?;
 
     Ok(res)
 }
@@ -652,7 +653,6 @@ mod tests {
 
         let ex = Experiment {
             name: "foo".to_string(),
-            crates: vec![gh.clone()],
             toolchains: [MAIN_TOOLCHAIN.clone(), TEST_TOOLCHAIN.clone()],
             mode: Mode::BuildAndTest,
             cap_lints: CapLints::Forbid,
@@ -695,7 +695,7 @@ mod tests {
         );
 
         let writer = DummyWriter::default();
-        gen(&db, &ex, &writer, &config).unwrap();
+        gen(&db, &ex, &vec![gh], &writer, &config).unwrap();
 
         assert_eq!(
             writer.get("config.json", &mime::APPLICATION_JSON),

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -695,7 +695,7 @@ mod tests {
         );
 
         let writer = DummyWriter::default();
-        gen(&db, &ex, &vec![gh], &writer, &config).unwrap();
+        gen(&db, &ex, &[gh], &writer, &config).unwrap();
 
         assert_eq!(
             writer.get("config.json", &mime::APPLICATION_JSON),

--- a/src/runner/graph.rs
+++ b/src/runner/graph.rs
@@ -17,6 +17,7 @@
 //                                   +---+ tc2 <---+
 
 use crate::config::Config;
+use crate::crates::Crate;
 use crate::experiments::{Experiment, Mode};
 use crate::prelude::*;
 use crate::results::{TestResult, WriteResults};
@@ -223,10 +224,10 @@ impl TasksGraph {
     }
 }
 
-pub(super) fn build_graph(ex: &Experiment, config: &Config) -> TasksGraph {
+pub(super) fn build_graph(ex: &Experiment, crates: &[Crate], config: &Config) -> TasksGraph {
     let mut graph = TasksGraph::new();
 
-    for krate in &ex.crates {
+    for krate in crates {
         if !ex.ignore_blacklist && config.should_skip(krate) {
             continue;
         }

--- a/src/server/reports.rs
+++ b/src/server/reports.rs
@@ -23,7 +23,8 @@ fn generate_report(data: &Data, ex: &Experiment, results: &DatabaseDB) -> Fallib
     let dest = format!("s3://{}/{}", data.tokens.reports_bucket.bucket, &ex.name);
     let writer = report::S3Writer::create(Box::new(client), dest.parse()?)?;
 
-    let res = report::gen(results, &ex, &writer, &data.config)?;
+    let crates = ex.get_crates(&data.db)?;
+    let res = report::gen(results, &ex, &crates, &writer, &data.config)?;
 
     Ok(res)
 }

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -109,7 +109,7 @@ fn endpoint_next_experiment(data: Arc<Data>, auth: AuthDetails) -> Fallible<Resp
             }
         }
 
-        Some((ex.clone(), ex.get_crates(&data.db)?))
+        Some((ex.clone(), ex.get_uncompleted_crates(&data.db)?))
     } else {
         None
     };

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -94,7 +94,7 @@ fn endpoint_config(data: Arc<Data>, auth: AuthDetails) -> Fallible<Response<Body
 fn endpoint_next_experiment(data: Arc<Data>, auth: AuthDetails) -> Fallible<Response<Body>> {
     let next = Experiment::next(&data.db, &Assignee::Agent(auth.name.clone()))?;
 
-    let result = if let Some((new, mut ex)) = next {
+    let result = if let Some((new, ex)) = next {
         if new {
             if let Some(ref github_issue) = ex.github_issue {
                 Message::new()
@@ -109,8 +109,7 @@ fn endpoint_next_experiment(data: Arc<Data>, auth: AuthDetails) -> Fallible<Resp
             }
         }
 
-        ex.remove_completed_crates(&data.db)?;
-        Some(ex)
+        Some((ex.clone(), ex.get_crates(&data.db)?))
     } else {
         None
     };


### PR DESCRIPTION
`Experiment` does not hold anymore the list of crates. Instead, relevant crates can be queried with a new method `get_crates(db: &Database) -> Vec<Crate>`.
As a consequence, `next_experiment` from agent api now returns both an `Experiment` and a `Vec<Crate>` and runner require also a `&[Crate]` argument besides the experiment.
