### PR TITLE
Cleanup target directory when the disk is full

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cc"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +311,7 @@ dependencies = [
  "sha-1 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "systemstat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 0.11.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -973,6 +979,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1144,6 +1158,14 @@ dependencies = [
 name = "nodrop"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -1933,6 +1955,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "systemstat"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytesize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,6 +2579,7 @@ dependencies = [
 "checksum byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "980479e6fde23246dfb54d47580d66b4e99202e7579c5eaa9fe10ecb5ebd2182"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
+"checksum bytesize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "16d794c5fe594cfa8fbe8ae274de4048176c69f2d9ac5e637166e73b71d460b8"
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
@@ -2628,6 +2665,7 @@ dependencies = [
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0a907b83e7b9e987032439a387e187119cddafc92d5c2aaeb1d92580a793f630"
@@ -2645,6 +2683,7 @@ dependencies = [
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
+"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e0a1a39eab95caf4f5556da9289b9e68f0aafac901b2ce80daaf020d3b733a8"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
@@ -2735,6 +2774,7 @@ dependencies = [
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)" = "90c39a061e2f412a9f869540471ab679e85e50c6b05604daf28bc3060f75c430"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum systemstat 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "11374381f619810a32d086459e740a0e4a683f15beea3fe5f3cddb40c8791106"
 "checksum tar 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)" = "83b0d14b53dbfd62681933fadd651e815f99e6084b649e049ab99296e05ab3de"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
 "checksum tera 0.11.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac6d8ad623a7efcfb4367ce2a36f84ef849d5aa3c7bcf2e0324c4cbcc57ebaf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ env_logger = "0.6.0"
 hmac = "0.7"
 sha-1 = "0.8"
 rust_team_data = { git = "https://github.com/rust-lang/team" }
+systemstat = "0.1.4"
 
 [dev-dependencies]
 assert_cmd = "0.10.1"

--- a/src/runner/worker.rs
+++ b/src/runner/worker.rs
@@ -7,8 +7,15 @@ use crate::runner::graph::{TasksGraph, WalkResult};
 use crate::runner::{OverrideResult, RunnerState};
 use crate::utils;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::path::Path;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc::{self, RecvTimeoutError},
+    Arc, Mutex,
+};
 use std::thread;
+use std::time::Duration;
+use systemstat::{Filesystem, Platform, System};
 
 pub(super) struct Worker<'a, DB: WriteResults + Sync> {
     name: String,
@@ -19,6 +26,7 @@ pub(super) struct Worker<'a, DB: WriteResults + Sync> {
     db: &'a DB,
     docker_env: &'a DockerEnv,
     parked_threads: &'a Mutex<HashMap<thread::ThreadId, thread::Thread>>,
+    target_dir_cleanup: AtomicBool,
 }
 
 impl<'a, DB: WriteResults + Sync> Worker<'a, DB> {
@@ -41,6 +49,7 @@ impl<'a, DB: WriteResults + Sync> Worker<'a, DB> {
             db,
             docker_env,
             parked_threads,
+            target_dir_cleanup: AtomicBool::new(false),
         }
     }
 
@@ -51,6 +60,7 @@ impl<'a, DB: WriteResults + Sync> Worker<'a, DB> {
     pub(super) fn run(&self) -> Fallible<()> {
         // This uses a `loop` instead of a `while let` to avoid locking the graph too much
         loop {
+            self.maybe_cleanup_target_dir()?;
             let walk_result = self.graph.lock().unwrap().next_task(self.ex, self.db);
             match walk_result {
                 WalkResult::Task(id, task) => {
@@ -110,5 +120,102 @@ impl<'a, DB: WriteResults + Sync> Worker<'a, DB> {
         }
 
         Ok(())
+    }
+
+    fn maybe_cleanup_target_dir(&self) -> Fallible<()> {
+        if !self.target_dir_cleanup.swap(false, Ordering::SeqCst) {
+            return Ok(());
+        }
+        let target_dir = crate::dirs::TARGET_DIR.join(&self.ex.name).join(&self.name);
+        if target_dir.is_dir() {
+            info!("removing target dir {}", target_dir.display());
+            crate::utils::fs::remove_dir_all(&target_dir)?;
+            info!("removed target dir {}", target_dir.display());
+        }
+        Ok(())
+    }
+
+    fn schedule_target_dir_cleanup(&self) {
+        self.target_dir_cleanup.store(true, Ordering::SeqCst);
+    }
+}
+
+pub(super) struct DiskSpaceWatcher<'a, DB: WriteResults + Sync> {
+    interval: Duration,
+    threshold: f32,
+    workers: &'a [Worker<'a, DB>],
+    stop_send: Arc<Mutex<mpsc::Sender<()>>>,
+    stop_recv: Arc<Mutex<mpsc::Receiver<()>>>,
+}
+
+impl<'a, DB: WriteResults + Sync> DiskSpaceWatcher<'a, DB> {
+    pub(super) fn new(interval: Duration, threshold: f32, workers: &'a [Worker<'a, DB>]) -> Self {
+        let (stop_send, stop_recv) = mpsc::channel();
+        DiskSpaceWatcher {
+            interval,
+            threshold,
+            workers,
+            stop_send: Arc::new(Mutex::new(stop_send)),
+            stop_recv: Arc::new(Mutex::new(stop_recv)),
+        }
+    }
+
+    pub(super) fn stop(&self) {
+        self.stop_send.lock().unwrap().send(()).unwrap();
+    }
+
+    pub(super) fn run(&self) -> Fallible<()> {
+        loop {
+            self.check()?;
+            match self.stop_recv.lock().unwrap().recv_timeout(self.interval) {
+                Ok(()) => return Ok(()),
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => panic!("disconnected stop channel"),
+            }
+        }
+    }
+
+    fn check(&self) -> Fallible<()> {
+        let fs = self.current_mount()?;
+        let usage = (fs.total.as_usize() - fs.free.as_usize()) as f32 / fs.total.as_usize() as f32;
+        if usage < self.threshold {
+            info!(
+                "{} disk usage at {}%",
+                fs.fs_mounted_on,
+                (usage * 100.0) as u8
+            );
+        } else {
+            warn!(
+                "{} disk usage at {}%, which is over the threshold of {}%",
+                fs.fs_mounted_on,
+                (usage * 100.0) as u8,
+                (self.threshold * 100.0) as u8,
+            );
+
+            for worker in self.workers {
+                worker.schedule_target_dir_cleanup();
+            }
+            warn!("scheduled cleanup");
+        }
+        Ok(())
+    }
+
+    fn current_mount(&self) -> Fallible<Filesystem> {
+        let current_dir = crate::dirs::WORK_DIR.canonicalize()?;
+        let system = System::new();
+
+        let mut found = None;
+        let mut found_pos = std::usize::MAX;
+        for mount in system.mounts()?.into_iter() {
+            let path = Path::new(&mount.fs_mounted_on);
+            for (i, ancestor) in current_dir.ancestors().enumerate() {
+                if ancestor == path && i < found_pos {
+                    found_pos = i;
+                    found = Some(mount);
+                    break;
+                }
+            }
+        }
+        found.ok_or_else(|| failure::err_msg("failed to find the current mount"))
     }
 }

--- a/src/runner/worker.rs
+++ b/src/runner/worker.rs
@@ -1,0 +1,114 @@
+use crate::config::Config;
+use crate::docker::DockerEnv;
+use crate::experiments::Experiment;
+use crate::prelude::*;
+use crate::results::{BrokenReason, TestResult, WriteResults};
+use crate::runner::graph::{TasksGraph, WalkResult};
+use crate::runner::{OverrideResult, RunnerState};
+use crate::utils;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::thread;
+
+pub(super) struct Worker<'a, DB: WriteResults + Sync> {
+    name: String,
+    ex: &'a Experiment,
+    config: &'a Config,
+    graph: &'a Mutex<TasksGraph>,
+    state: &'a RunnerState,
+    db: &'a DB,
+    docker_env: &'a DockerEnv,
+    parked_threads: &'a Mutex<HashMap<thread::ThreadId, thread::Thread>>,
+}
+
+impl<'a, DB: WriteResults + Sync> Worker<'a, DB> {
+    pub(super) fn new(
+        name: String,
+        ex: &'a Experiment,
+        config: &'a Config,
+        graph: &'a Mutex<TasksGraph>,
+        state: &'a RunnerState,
+        db: &'a DB,
+        docker_env: &'a DockerEnv,
+        parked_threads: &'a Mutex<HashMap<thread::ThreadId, thread::Thread>>,
+    ) -> Self {
+        Worker {
+            name,
+            ex,
+            config,
+            graph,
+            state,
+            db,
+            docker_env,
+            parked_threads,
+        }
+    }
+
+    pub(super) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(super) fn run(&self) -> Fallible<()> {
+        // This uses a `loop` instead of a `while let` to avoid locking the graph too much
+        loop {
+            let walk_result = self.graph.lock().unwrap().next_task(self.ex, self.db);
+            match walk_result {
+                WalkResult::Task(id, task) => {
+                    info!("running task: {:?}", task);
+                    if let Err(e) =
+                        task.run(self.config, self.ex, self.db, self.docker_env, self.state)
+                    {
+                        error!("task failed, marking childs as failed too: {:?}", task);
+                        utils::report_failure(&e);
+
+                        let mut result = if self.config.is_broken(&task.krate) {
+                            TestResult::BrokenCrate(BrokenReason::Unknown)
+                        } else {
+                            TestResult::Error
+                        };
+
+                        for err in e.iter_chain() {
+                            if let Some(&OverrideResult(res)) = err.downcast_ctx() {
+                                result = res;
+                                break;
+                            }
+                        }
+
+                        self.graph.lock().unwrap().mark_as_failed(
+                            id,
+                            self.ex,
+                            self.db,
+                            self.state,
+                            self.config,
+                            &e,
+                            result,
+                        )?;
+                    } else {
+                        self.graph.lock().unwrap().mark_as_completed(id);
+                    }
+
+                    // Unpark all the threads
+                    let mut parked = self.parked_threads.lock().unwrap();
+                    for (_id, thread) in parked.drain() {
+                        thread.unpark();
+                    }
+                }
+                WalkResult::Blocked => {
+                    // Wait until another thread finished before looking for tasks again
+                    // If the thread spuriously wake up (parking does not guarantee no
+                    // spurious wakeups) it's not a big deal, it will just get parked again
+                    {
+                        let mut parked_threads = self.parked_threads.lock().unwrap();
+                        let current = thread::current();
+                        parked_threads.insert(current.id(), current);
+                    }
+                    thread::park();
+                }
+                WalkResult::NotBlocked => unreachable!("NotBlocked leaked from the run"),
+                WalkResult::Finished => break,
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR removes all target directories after disk usage reaches 90% on the partition containing the work directory. Each worker thread will cleanup its own directory when it's not busy, to avoid disrupting running tests.

cc @Mark-Simulacrum 