### PR TITLE
Experiment in endpoints

### DIFF
--- a/docs/agent-http-api.md
+++ b/docs/agent-http-api.md
@@ -147,7 +147,7 @@ This endpoint uploads the result of a single job run by the agent to the Crater
 server. The endpoint expects the following data to be provided as the request
 body, encoded in JSON:
 
-* `experiment_name`: the name of the experiment being run
+* `experiment-name`: the name of the experiment being run
 * `results`: a list of job results that should be recorded:
 
     * `crate`: the serialized crate name
@@ -219,7 +219,7 @@ This endpoint tells the Crater server the agent has encountered an error.
 The endpoint expects the error description to be provided as the request body,
 encoded in JSON:
 
-* `experiment_name`: the name of the experiment being run
+* `experiment-name`: the name of the experiment being run
 * `error`: a description of the error
 
 For example, this is a valid request data:

--- a/docs/agent-http-api.md
+++ b/docs/agent-http-api.md
@@ -147,43 +147,48 @@ This endpoint uploads the result of a single job run by the agent to the Crater
 server. The endpoint expects the following data to be provided as the request
 body, encoded in JSON:
 
-* `results`: a list of job results that should be recorded:
+* `experiment_name`: the name of the experiment being run
+* `data`: the data from the job you want to upload:
+    * `results`: a list of job results that should be recorded:
 
-    * `crate`: the serialized crate name
-    * `toolchain`: the serialized toolchain name
-    * `result`: the result of the experiment (for example `TestPass`)
-    * `log`: the base64-encoded output of the job
+        * `crate`: the serialized crate name
+        * `toolchain`: the serialized toolchain name
+        * `result`: the result of the experiment (for example `TestPass`)
+        * `log`: the base64-encoded output of the job
 
-* `shas`: a list of GitHub repo shas captured during the job; can be empty
+    * `shas`: a list of GitHub repo shas captured during the job; can be empty
 
 For example, this is a valid request data:
 
 ```json
 {
-    "results": [
-        {
-            "crate": {
-                "GitHub": {
-                    "org": "brson",
-                    "repo": "hello-rs"
-                }
-            },
-            "toolchain": {
-                "Dist": "stable"
-            },
-            "result": "TestPass",
-            "log": "cGlhZGluYSByb21hZ25vbGE="
-        }
-    ],
-    "shas": [
-        [
+    "experiment_name": "pr-1",
+    "data": {
+        "results": [
             {
-                "org": "brson",
-                "name": "hello-rs"
-            },
-            "f45e5e3289dd46aaec8392134a12c019aca3d117"
+                "crate": {
+                    "GitHub": {
+                        "org": "brson",
+                        "repo": "hello-rs"
+                    }
+                },
+                "toolchain": {
+                    "Dist": "stable"
+                },
+                "result": "TestPass",
+                "log": "cGlhZGluYSByb21hZ25vbGE="
+            }
+        ],
+        "shas": [
+            [
+                {
+                    "org": "brson",
+                    "name": "hello-rs"
+                },
+                "f45e5e3289dd46aaec8392134a12c019aca3d117"
+            ]
         ]
-    ]
+    }
 }
 ```
 
@@ -217,13 +222,18 @@ This endpoint tells the Crater server the agent has encountered an error.
 The endpoint expects the error description to be provided as the request body,
 encoded in JSON:
 
-* `error`: a description of the error
+* `experiment_name`: the name of the experiment being run
+* `data`: the data you want to upload to the server:
+    * `error`: a description of the error
 
 For example, this is a valid request data:
 
 ```json
 {
-    "error": "pc is not powered on"
+    "experiment_name": "pr-1",
+    "data": {
+        "error": "pc is not powered on"
+    }
 }
 ```
 

--- a/docs/agent-http-api.md
+++ b/docs/agent-http-api.md
@@ -162,33 +162,31 @@ For example, this is a valid request data:
 
 ```json
 {
-    "experiment_name": "pr-1",
-    "data": {
-        "results": [
-            {
-                "crate": {
-                    "GitHub": {
-                        "org": "brson",
-                        "repo": "hello-rs"
-                    }
-                },
-                "toolchain": {
-                    "Dist": "stable"
-                },
-                "result": "TestPass",
-                "log": "cGlhZGluYSByb21hZ25vbGE="
-            }
-        ],
-        "shas": [
-            [
-                {
+    "experiment-name": "pr-1",
+    "results": [
+        {
+            "crate": {
+                "GitHub": {
                     "org": "brson",
-                    "name": "hello-rs"
-                },
-                "f45e5e3289dd46aaec8392134a12c019aca3d117"
-            ]
+                    "repo": "hello-rs"
+                }
+            },
+            "toolchain": {
+                "Dist": "stable"
+            },
+            "result": "TestPass",
+            "log": "cGlhZGluYSByb21hZ25vbGE="
+        }
+    ],
+    "shas": [
+        [
+            {
+                "org": "brson",
+                "name": "hello-rs"
+            },
+            "f45e5e3289dd46aaec8392134a12c019aca3d117"
         ]
-    }
+    ]
 }
 ```
 
@@ -230,10 +228,8 @@ For example, this is a valid request data:
 
 ```json
 {
-    "experiment_name": "pr-1",
-    "data": {
-        "error": "pc is not powered on"
-    }
+    "experiment-name": "pr-1",
+    "error": "pc is not powered on"
 }
 ```
 

--- a/docs/agent-http-api.md
+++ b/docs/agent-http-api.md
@@ -148,15 +148,14 @@ server. The endpoint expects the following data to be provided as the request
 body, encoded in JSON:
 
 * `experiment_name`: the name of the experiment being run
-* `data`: the data from the job you want to upload:
-    * `results`: a list of job results that should be recorded:
+* `results`: a list of job results that should be recorded:
 
-        * `crate`: the serialized crate name
-        * `toolchain`: the serialized toolchain name
-        * `result`: the result of the experiment (for example `TestPass`)
-        * `log`: the base64-encoded output of the job
+    * `crate`: the serialized crate name
+    * `toolchain`: the serialized toolchain name
+    * `result`: the result of the experiment (for example `TestPass`)
+    * `log`: the base64-encoded output of the job
 
-    * `shas`: a list of GitHub repo shas captured during the job; can be empty
+* `shas`: a list of GitHub repo shas captured during the job; can be empty
 
 For example, this is a valid request data:
 
@@ -221,8 +220,7 @@ The endpoint expects the error description to be provided as the request body,
 encoded in JSON:
 
 * `experiment_name`: the name of the experiment being run
-* `data`: the data you want to upload to the server:
-    * `error`: a description of the error
+* `error`: a description of the error
 
 For example, this is a valid request data:
 

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -193,7 +193,9 @@ impl AgentApi {
                 .json(ex)
                 .json(&json!({
                     "name" : ex.name,
-                    "error": error
+                    "data" : {
+                        "error": error
+                    }
                 }))
                 .send()?
                 .to_api_response()?;

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -145,6 +145,7 @@ impl AgentApi {
 
     pub fn record_progress(
         &self,
+        ex: &Experiment,
         krate: &Crate,
         toolchain: &Toolchain,
         log: &[u8],
@@ -154,6 +155,7 @@ impl AgentApi {
         self.retry(|this| {
             let _: bool = this
                 .build_request(Method::POST, "record-progress")
+                .json(ex)
                 .json(&json!({
                     "results": [
                         {
@@ -181,10 +183,11 @@ impl AgentApi {
         })
     }
 
-    pub fn report_error(&self, error: String) -> Fallible<()> {
+    pub fn report_error(&self, ex: &Experiment, error: String) -> Fallible<()> {
         self.retry(|this| {
             let _: bool = this
                 .build_request(Method::POST, "error")
+                .json(ex)
                 .json(&json!({ "error": error }))
                 .send()?
                 .to_api_response()?;

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -155,10 +155,9 @@ impl AgentApi {
         self.retry(|this| {
             let _: bool = this
                 .build_request(Method::POST, "record-progress")
-                .json(&json!(
-                    {
-                        "experiment_name": ex.name,
-                        "data" : {"results": [
+                .json(&json!({
+                    "experiment-name": ex.name,
+                    "results": [
                             {
                                 "crate": krate,
                                 "toolchain": toolchain,
@@ -166,9 +165,7 @@ impl AgentApi {
                                 "log": base64::encode(log),
                             },
                         ],
-                        "shas": shas,
-                    }
-
+                    "shas": shas,
                 }))
                 .send()?
                 .to_api_response()?;
@@ -192,10 +189,8 @@ impl AgentApi {
                 .build_request(Method::POST, "error")
                 .json(ex)
                 .json(&json!({
-                    "experiment_name" : ex.name,
-                    "data" : {
-                        "error": error
-                    }
+                    "experiment-name": ex.name,
+                    "error": error
                 }))
                 .send()?
                 .to_api_response()?;

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -158,13 +158,13 @@ impl AgentApi {
                 .json(&json!({
                     "experiment-name": ex.name,
                     "results": [
-                            {
-                                "crate": krate,
-                                "toolchain": toolchain,
-                                "result": result,
-                                "log": base64::encode(log),
-                            },
-                        ],
+                        {
+                            "crate": krate,
+                            "toolchain": toolchain,
+                            "result": result,
+                            "log": base64::encode(log),
+                        },
+                    ],
                     "shas": shas,
                 }))
                 .send()?
@@ -187,7 +187,6 @@ impl AgentApi {
         self.retry(|this| {
             let _: bool = this
                 .build_request(Method::POST, "error")
-                .json(ex)
                 .json(&json!({
                     "experiment-name": ex.name,
                     "error": error

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -157,7 +157,7 @@ impl AgentApi {
                 .build_request(Method::POST, "record-progress")
                 .json(&json!(
                     {
-                        "name": ex.name,
+                        "experiment_name": ex.name,
                         "data" : {"results": [
                             {
                                 "crate": krate,
@@ -192,7 +192,7 @@ impl AgentApi {
                 .build_request(Method::POST, "error")
                 .json(ex)
                 .json(&json!({
-                    "name" : ex.name,
+                    "experiment_name" : ex.name,
                     "data" : {
                         "error": error
                     }

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -155,17 +155,20 @@ impl AgentApi {
         self.retry(|this| {
             let _: bool = this
                 .build_request(Method::POST, "record-progress")
-                .json(ex)
-                .json(&json!({
-                    "results": [
-                        {
-                            "crate": krate,
-                            "toolchain": toolchain,
-                            "result": result,
-                            "log": base64::encode(log),
-                        },
-                    ],
-                    "shas": shas,
+                .json(&json!(
+                    {
+                        "name": ex.name,
+                        "data" : {"results": [
+                            {
+                                "crate": krate,
+                                "toolchain": toolchain,
+                                "result": result,
+                                "log": base64::encode(log),
+                            },
+                        ],
+                        "shas": shas,
+                    }
+
                 }))
                 .send()?
                 .to_api_response()?;
@@ -188,7 +191,10 @@ impl AgentApi {
             let _: bool = this
                 .build_request(Method::POST, "error")
                 .json(ex)
-                .json(&json!({ "error": error }))
+                .json(&json!({
+                    "name" : ex.name,
+                    "error": error
+                }))
                 .send()?
                 .to_api_response()?;
             Ok(())

--- a/src/agent/results.rs
+++ b/src/agent/results.rs
@@ -46,7 +46,7 @@ impl<'a> WriteResults for ResultsUploader<'a> {
 
     fn record_result<F>(
         &self,
-        _ex: &Experiment,
+        ex: &Experiment,
         toolchain: &Toolchain,
         krate: &Crate,
         existing_logs: Option<LogStorage>,
@@ -65,7 +65,7 @@ impl<'a> WriteResults for ResultsUploader<'a> {
 
         info!("sending results to the crater server...");
         self.api
-            .record_progress(krate, toolchain, output.as_bytes(), result, &shas)?;
+            .record_progress(ex, krate, toolchain, output.as_bytes(), result, &shas)?;
 
         Ok(result)
     }

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -13,8 +13,10 @@ use std::sync::Arc;
 use warp::{self, Filter, Rejection};
 
 #[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct ExperimentData<T> {
     experiment_name: String,
+    #[serde(flatten)]
     data: T,
 }
 

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -119,7 +119,7 @@ fn endpoint_record_progress(
     data: Arc<Data>,
     auth: AuthDetails,
 ) -> Fallible<Response<Body>> {
-    let mut ex = Experiment::get(&data.db, &result.name)?
+    let mut ex = Experiment::get(&data.db, &result.experiment_name)?
         .ok_or_else(|| err_msg("no experiment run by this agent"))?;
 
     info!(
@@ -154,7 +154,7 @@ fn endpoint_error(
     data: Arc<Data>,
     _auth: AuthDetails,
 ) -> Fallible<Response<Body>> {
-    let mut ex = Experiment::get(&data.db, &error.name)?
+    let mut ex = Experiment::get(&data.db, &error.experiment_name)?
         .ok_or_else(|| err_msg("no experiment run by this agent"))?;
 
     ex.set_status(&data.db, Status::Failed)?;

--- a/src/server/routes/agent.rs
+++ b/src/server/routes/agent.rs
@@ -14,7 +14,7 @@ use warp::{self, Filter, Rejection};
 
 #[derive(Deserialize)]
 pub struct ExperimentData<T> {
-    name: String,
+    experiment_name: String,
     data: T,
 }
 


### PR DESCRIPTION
`record-progress` and `error` endpoints now need the name of the experiment being run by the agent.  In order to do this, I've created a new struct `ExperimentData<T>`, which represents data related to a particular experiment and holds the experiment name as well as T. As a result of this:
* `record-progress` accepts a `ExperimentData<ProgressData>` instead of `ProgressData`
* `error` accepts a `ExperimentData<HashMap<String, String>>` instead of `HashMap<String, String>`
