### PR TITLE
add another exception

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -168,5 +168,6 @@ crokey = { skip-tests = true } # compiler error checks in tests
 "naomijub/genetic-labyrinth" = { skip-tests = true } # flaky tests
 "sachaarbonel/trie.rs" = { skip-tests = true } # flaky tests
 "vspecky/neat-rs" = { skip-tests = true } # flaky tests
+"mistrpopo/MandelbrotAnimation" = { skip-tests = true } # second build seems to always fail
 
 [local-crates]


### PR DESCRIPTION
This failed with the same error in both runs in https://github.com/rust-lang/rust/pull/104429.

Doesn't crater run both builds in the same clean environment? We seem to have a bunch of cases of "baseline always works but try build always fails". It almost seems like the 'try' run can see artifacts created by the baseline, and that breaks quite a few poorly written build scripts out there.