### PR TITLE
Increase database connection pool

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -120,7 +120,11 @@ impl Database {
 
     fn new(conn: SqliteConnectionManager, tempfile: Option<NamedTempFile>) -> Fallible<Self> {
         let pool = Pool::builder()
-            .connection_timeout(Duration::from_secs(5))
+            // By inspection we have 13 threads in production, so make sure each of them can get a
+            // connection. In practice some of those wouldn't acquire database connections (e.g.,
+            // the ctrl-c thread) but this seems like a good idea regardless.
+            .max_size(20)
+            .connection_timeout(Duration::from_secs(30))
             .error_handler(Box::new(ErrorHandler))
             .build(conn)?;
 


### PR DESCRIPTION
sqlite shouldn't actually care about the number of open connections, and it's not clear that we need a pool at all, but this seems like it may resolve the issues we're seeing timing out acquiring a connection.