### PR TITLE
Fix typo `regessed`

### DIFF
--- a/src/server/reports.rs
+++ b/src/server/reports.rs
@@ -129,7 +129,7 @@ fn reports_thread(data: &Data, github_data: Option<&GithubData>) -> Fallible<()>
                                     res.info.values().sum::<u32>(),
                                 ),
                             )
-                            .line("bar_chart", format!("{spurious_retry} spurious results on the [retry-regessed-list.txt]({retry_regressed_list_url}), consider a retry[^1] if this is a significant amount."))
+                            .line("bar_chart", format!("{spurious_retry} spurious results on the [retry-regressed-list.txt]({retry_regressed_list_url}), consider a retry[^1] if this is a significant amount."))
                             .footnote("1", format!("re-run the experiment with `crates={retry_regressed_list_url}`"))
                             .line(
                                 "newspaper",


### PR DESCRIPTION
regessed -> regressed
The url it points to is correct.