### PR TITLE
RecordProgress for DatabaseDB (cli mode) fix to record result for the updated crate name

### DIFF
--- a/src/results/db.rs
+++ b/src/results/db.rs
@@ -266,10 +266,13 @@ impl crate::runner::RecordProgress for DatabaseDB<'_> {
         result: &TestResult,
         version: Option<(&Crate, &Crate)>,
     ) -> Fallible<()> {
-        self.store_result(ex, krate, toolchain, result, log, EncodingType::Plain)?;
-        if let Some((old, new)) = version {
+        let krate = if let Some((old, new)) = version {
             self.update_crate_version(ex, old, new)?;
-        }
+            new
+        } else {
+            krate
+        };
+        self.store_result(ex, krate, toolchain, result, log, EncodingType::Plain)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Bug in cli mode: `record_progress` for `DatabaseDB` stores not updated crate name in `results` table. While `update_crate_version` writes updated crate name into `experiment_crates` table. So, when report is generated, logs for the new crate name can't be found:
```
[2026-01-18T15:05:30Z ERROR crater::utils] failed to read log of brson/hello-rs/9da3b03b25c2dfa8a8b8a69db503c48dbd08610e on stable
[2026-01-18T15:05:30Z ERROR crater::utils] caused by: failed to read log of brson/hello-rs/9da3b03b25c2dfa8a8b8a69db503c48dbd08610e on stable
[2026-01-18T15:05:30Z ERROR crater::utils] caused by: missing logs
```
Because results are stored for "brson/hello-rs", not "brson/hello-rs/9da3b03b25c2dfa8a8b8a69db503c48dbd08610e".

In agent mode this problem was already fixed in `pub fn store(...)`:
```
        let krate = if let Some((old, new)) = &data.version {
            // If we're updating the name of the crate (typically changing the hash we found on
            // github) then we ought to also use that new name for marking the crate as complete.
            // Otherwise, we leave behind the old (unversioned) name and end up running this crate
            // many times, effectively never actually completing it.
            self.update_crate_version(ex, old, new)?;

            // sanity check that the previous name of the crate is the one we intended to run.
            if old.id() != data.result.krate.id() {
                log::warn!(
                    "Storing result under {} despite job intended for {} (with wrong name old={})",
                    new.id(),
                    data.result.krate.id(),
                    old.id(),
                );
            }

            new
        } else {
            &data.result.krate
        };

        self.store_result(
            ex,
            krate,
```

This PR fixes the problem in cli mode in the similar way.
