### PR TITLE
security: pin GitHub Actions to commit SHAs and add audit workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust nightly
         run: rustup update nightly && rustup default nightly && rustup component add rustfmt clippy
@@ -26,7 +28,9 @@ jobs:
         channel: [nightly]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust ${{ matrix.channel }}
         shell: bash
@@ -51,7 +55,9 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust nightly
         run: rustup update --no-self-update nightly && rustup default nightly
@@ -69,7 +75,9 @@ jobs:
     name: Build the Docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build the Docker image
         run: docker build -t crater .
@@ -80,7 +88,7 @@ jobs:
           docker save crater | gzip > /tmp/docker-images/crater.tar.gz
 
       - name: Upload the image to GitHub Actions artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docker-images
           path: /tmp/docker-images
@@ -96,7 +104,7 @@ jobs:
 
     steps:
       - name: Download the image from GitHub Actions artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: docker-images
           path: docker-images
@@ -105,7 +113,7 @@ jobs:
         run: cat docker-images/crater.tar.gz | gunzip | docker load
 
       - name: Upload the Docker image to ECR
-        uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master
+        uses: rust-lang/simpleinfra/github-actions/upload-docker-image@4da88c824d96c01628fbad1e1b97cd24e08216c4 # master (2026-04-10)
         with:
           image: crater
           repository: crater
@@ -114,6 +122,7 @@ jobs:
           aws_secret_access_key: "${{ secrets.aws_secret_access_key }}"
 
   conclusion:
+    name: Conclusion
     needs: [docker-upload]
     # We need to ensure this job does *not* get skipped if its dependencies fail,
     # because a skipped job is considered a success by GitHub. So we have to

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,9 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust nightly
         run: rustup update nightly && rustup default nightly && rustup component add rustfmt clippy
@@ -21,7 +23,9 @@ jobs:
     name: Linux testing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust nightly
         run: rustup update nightly && rustup default nightly
@@ -41,6 +45,7 @@ jobs:
   # Note: this job is used so that there is a job named "conclusion" both in the PR and merge queue
   # CI. Otherwise, it would not be possible for PR CI to succeed.
   conclusion:
+    name: Conclusion
     needs: [lint, test]
     # We need to ensure this job does *not* get skipped if its dependencies fail,
     # because a skipped job is considered a success by GitHub. So we have to

--- a/.github/workflows/zizmor-audit.yml
+++ b/.github/workflows/zizmor-audit.yml
@@ -1,0 +1,41 @@
+name: GitHub Actions Security Audit (zizmor)
+
+on:
+  pull_request:
+    branches: ["**"]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  merge_group:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  schedule:
+    # Run daily at 00:00 UTC to catch newly-disclosed vulnerabilities
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Read repository to scan workflows
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor security audit
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          inputs: .github/workflows/
+          persona: pedantic
+          annotations: true
+          advanced-security: false


### PR DESCRIPTION
## Summary

This PR fixes all HIGH severity zizmor security issues in crater's GitHub Actions workflows by pinning actions to commit SHAs and adds a preventive audit workflow.

## Changes

### Security Fixes (9 HIGH severity issues → 0)
- Pin `actions/checkout@v6` to v6.0.2 SHA (7 instances across ci.yml, pr.yml, zizmor-audit.yml)
- Pin `actions/upload-artifact@v4` to v4.6.2 SHA (ci.yml)
- Pin `actions/download-artifact@v4` to v4.3.0 SHA (ci.yml)
- Pin `rust-lang/simpleinfra@master` to specific commit SHA (ci.yml) - **Critical: this action receives AWS credentials**
- Add `persist-credentials: false` to all 6 checkout actions to prevent credential leakage

### Preventive Measures
- Add `.github/workflows/zizmor-audit.yml` workflow for continuous security monitoring
  - Runs on PRs, merge queue, daily schedule, and manual dispatch
  - Uses pedantic persona for comprehensive analysis
  - Provides PR annotations for first 10 findings
  - All actions SHA-pinned (dogfooding)

### Code Quality
- Add `name: Conclusion` to conclusion jobs in ci.yml and pr.yml for better observability

## Validation

-  Tested locally with `zizmor --pedantic` (exit code 13, 0 HIGH issues)
-  Tested with `act` to simulate GitHub Actions execution
-  Follows rust-lang/team SHA pinning patterns
-  Matches versions that @v6/@v4 mutable tags currently resolve to

## Remaining Issues (Non-blocking)

13 MEDIUM severity issues remain (excessive-permissions, secrets-outside-env):
- **excessive-permissions** (11 issues): Requires careful per-job permission analysis, recommended for separate PR
- **secrets-outside-env** (2 issues): Requires org-level decision on environment strategy

These are documented but not fixed as they require architectural changes beyond the scope of security fixes.


 This PR is part of an Outreachy contribution to improve GitHub Actions security across rust-lang repositories.