### PR TITLE
Skip 2 crates

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -241,6 +241,7 @@ fp_lib = { skip-tests = true } # flaky test (thread::sleep; will fail on heavily
 "c0repwn3r/mangrove" = { skip = true } # broken beta rustc version parsing
 "zbzalex/rustc_get_version" = { skip = true } # broken beta rustc version parsing
 "ns6251/spin-cookie-token-sample" = { skip = true } # invalid dep tree, spuriously compiles
+"ecumene/spin_pg" = { skip = true } # invalid dep tree, spuriously compiles
 "daniestevez/qsdr" = { skip = true } # cfg for stable/nightly, but not beta
 "Buggaboo/flat_sqlite_rs" = { skip = true } # proc macro causes nondeterministic compile error
 "Arxoto/sudoku" = { skip-tests = true } # memory corruption with static mut
@@ -262,5 +263,6 @@ fp_lib = { skip-tests = true } # flaky test (thread::sleep; will fail on heavily
 "conradludgate/plunger" = { skip-tests = true } # flaky test (timing)
 "marziply/emotech-grpc" = { skip-tests = true } # flaky tests when run concurrently (all try to open socket on same address)
 "olegfomenko/valida-examples" = { skip-tests = true } # test requires custom toolchain and specific target
+"Steven9101/novasdr-wasm" = { skip = true } # depends on futuredsp, which has cfg for stable/nightly, but not beta
 
 [local-crates]


### PR DESCRIPTION
These two crates were discovered in the 1.96.0 beta crater run in https://github.com/rust-lang/rust/issues/155592#issuecomment-4346925032

"Steven9101/novasdr-wasm" depends on futuredsp, which already is skipped on crater due to having cfg's for stable/nightly but not for beta.

"ecumene/spin_pg" is another instance of the nondeterministic compile failures in https://github.com/rust-lang/rust/issues/137891#issuecomment-2699821424. This can be seened in https://github.com/ecumene/spin_pg/blob/594a522b1d7895c1573c33bb2d6f48ea215d76f4/Cargo.lock#L363-L381, where the crate depends on wit-bindgen-rust at two different commits.